### PR TITLE
feat(rules): add W011 union-without-all warning rule

### DIFF
--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -22,6 +22,7 @@ from sql_guard.rules.warnings import (
     SelectStar,
     SubqueryCouldBeJoin,
     CommentedOutCode,
+    UnionWithoutAll,
 )
 from sql_guard.rules.structural import (
     DeeplyNestedSubquery,
@@ -37,7 +38,7 @@ ALL_RULES: list[Rule] = [
     StringConcatInWhere(),
     InsertWithoutColumns(),
     UpdateWithoutWhere(),
-    # Warnings (W001-W010)
+    # Warnings (W001-W011)
     SelectStar(),
     MissingLimit(),
     FunctionOnIndexedColumn(),
@@ -48,6 +49,7 @@ ALL_RULES: list[Rule] = [
     MixedCaseKeywords(),
     MissingSemicolon(),
     CommentedOutCode(),
+    UnionWithoutAll(),
     # Structural (S001-S003)
     ImplicitCrossJoin(),
     DeeplyNestedSubquery(),

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -268,3 +268,27 @@ class CommentedOutCode(Rule):
                 suggestion="Remove dead code -- it's in version control history",
             )
         return None
+
+
+class UnionWithoutAll(Rule):
+    """W011: UNION without ALL forces sort-and-dedupe."""
+
+    id = "W011"
+    name = "union-without-all"
+    severity = "warning"
+    description = "UNION forces sort-and-dedupe -- use UNION ALL when duplicates are impossible"
+    multiline = True
+
+    _pattern = Rule._compile(r"\bUNION\b(?!\s+ALL\b)")
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if self._pattern.search(statement):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=start_line,
+                message="UNION without ALL -- sort-and-dedupe may be unnecessary",
+                suggestion="Use UNION ALL if duplicate rows are impossible or undesired to remove",
+            )
+        return None

--- a/tests/fixtures/warnings.sql
+++ b/tests/fixtures/warnings.sql
@@ -11,3 +11,8 @@ SELECT id FROM orders WHERE amount > 10000;
 
 -- W010: Commented-out code
 -- SELECT * FROM deleted_users;
+
+-- W011: UNION without ALL
+SELECT id FROM orders_2024
+UNION
+SELECT id FROM orders_2025;

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -18,17 +18,17 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestRuleRegistry:
     def test_all_rules_loaded(self) -> None:
-        assert len(ALL_RULES) == 19
+        assert len(ALL_RULES) == 20
 
     def test_6_errors(self) -> None:
         errors = [r for r in ALL_RULES if r.severity == "error"]
         assert len(errors) == 6
 
-    def test_13_warnings(self) -> None:
-        # 10 "warning" (W-series) + 3 structural (S-series) all share the
+    def test_14_warnings(self) -> None:
+        # 11 "warning" (W-series) + 3 structural (S-series) all share the
         # "warning" severity in the registry.
         warnings = [r for r in ALL_RULES if r.severity == "warning"]
-        assert len(warnings) == 13
+        assert len(warnings) == 14
 
     def test_unique_ids(self) -> None:
         ids = [r.id for r in ALL_RULES]
@@ -116,6 +116,18 @@ class TestWarningRules:
         findings = check([str(FIXTURES / "warnings.sql")])
         w010 = [f for f in findings.findings if f.rule_id == "W010"]
         assert len(w010) >= 1
+
+    def test_w011_union_without_all(self) -> None:
+        findings = check([str(FIXTURES / "warnings.sql")])
+        w011 = [f for f in findings.findings if f.rule_id == "W011"]
+        assert len(w011) >= 1
+
+    def test_w011_passes_on_union_all(self) -> None:
+        from sql_guard.rules.warnings import UnionWithoutAll
+
+        rule = UnionWithoutAll()
+        statement = "SELECT id FROM orders_2024\nUNION ALL\nSELECT id FROM orders_2025;"
+        assert rule.check_statement(statement, 1, "test.sql") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements `W011 union-without-all` per #1. The rule warns when `UNION` is used without `ALL`, since bare `UNION` forces a sort-and-dedupe pass that is often unnecessary when the two sides are disjoint (different date-range tables, different customer IDs, etc.).

## Why this matters

The issue body flags a real cost: `UNION` forces a sort-and-dedupe pass while `UNION ALL` concatenates. On large result sets the difference is often an order of magnitude. `W011` is an advisory warning so the author has to actively justify the dedupe cost.

Mirrors the single-statement multiline shape of the existing `SubqueryCouldBeJoin` (W005) rule that the issue cited as the template. Regex `UNION(?!\s+ALL)` matches bare `UNION` but not `UNION ALL`.

## Changes

- `sql_guard/rules/warnings.py`: new `UnionWithoutAll` class (W011). Copies the shape of `SubqueryCouldBeJoin` / `OrderByWithoutLimit` - multiline statement check, `Rule._compile(...)` pattern, standard `Finding` return.
- `sql_guard/rules/__init__.py`: import `UnionWithoutAll`, register it in `ALL_RULES` after `CommentedOutCode`, and bump the `# Warnings (W001-W010)` section comment to `W001-W011`.
- `tests/fixtures/warnings.sql`: add a triggering case (`UNION` between two `orders_*` selects).
- `tests/test_rules.py`:
  - `test_all_rules_loaded`: 19 -> 20
  - `test_13_warnings` -> `test_14_warnings`, 13 -> 14 (W-series goes 10 -> 11, plus the 3 structural)
  - `test_w011_union_without_all`: asserts a W011 finding fires on the fixture
  - `test_w011_passes_on_union_all`: constructs `UnionWithoutAll()` directly and asserts `UNION ALL` is NOT flagged (regression test for the lookahead)

## Testing

```
$ python -m pytest tests/test_rules.py -q
24 passed, 1 pre-existing duration_tracked failure unrelated to this change
```

The pre-existing `TestChecker.test_duration_tracked` failure (`assert 0.0 > 0`) is on `main` too; fast machines complete the check faster than the resolution of `time.perf_counter` captures. Not touched here.

Fixes #1

---

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
