### PR TITLE
feat(rules): add W012 group-by-ordinal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
+### Added
+- **W012 `group-by-ordinal`** - warns when `GROUP BY` uses positional
+  ordinals (`GROUP BY 1, 2`) instead of explicit column names. Ordinal
+  references are fragile to `SELECT` list reorders: inserting or
+  removing a column silently changes what the query groups by.
+  Explicit names are self-documenting and refactor-safe.
+
 ### Changed
 - Single-source the package version via importlib.metadata in sql_guard/__init__.py. pyproject.toml is now the only place a release number is hard-coded.
 - sqlparse is now a core dependency. Previously only in the [structural] extra, which meant S001-S003 silently no-op'd for users without it.

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -13,6 +13,7 @@ from sql_guard.rules.errors import (
 )
 from sql_guard.rules.warnings import (
     FunctionOnIndexedColumn,
+    GroupByOrdinal,
     HardcodedValues,
     MissingLimit,
     MissingSemicolon,
@@ -38,7 +39,7 @@ ALL_RULES: list[Rule] = [
     StringConcatInWhere(),
     InsertWithoutColumns(),
     UpdateWithoutWhere(),
-    # Warnings (W001-W011)
+    # Warnings (W001-W012)
     SelectStar(),
     MissingLimit(),
     FunctionOnIndexedColumn(),
@@ -50,6 +51,7 @@ ALL_RULES: list[Rule] = [
     MissingSemicolon(),
     CommentedOutCode(),
     UnionWithoutAll(),
+    GroupByOrdinal(),
     # Structural (S001-S003)
     ImplicitCrossJoin(),
     DeeplyNestedSubquery(),

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -270,6 +270,36 @@ class CommentedOutCode(Rule):
         return None
 
 
+class GroupByOrdinal(Rule):
+    """W012: GROUP BY <positional-ordinal> is terse but brittle."""
+
+    id = "W012"
+    name = "group-by-ordinal"
+    severity = "warning"
+    description = (
+        "GROUP BY by column position is non-portable and silently breaks if the "
+        "SELECT list is reordered"
+    )
+    multiline = True
+
+    # \b\d+\b only matches a pure integer token. Column names like 1st_quarter
+    # stay intact because '1' is followed by a word character, so the trailing
+    # word boundary does not hold — no false positives on digit-prefixed names.
+    _pattern = Rule._compile(r"\bGROUP\s+BY\s+\d+\b(\s*,\s*\d+\b)*")
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if self._pattern.search(statement):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=start_line,
+                message="GROUP BY by ordinal position -- fragile, reorder-sensitive",
+                suggestion="Use explicit column names in GROUP BY to survive SELECT list reorders",
+            )
+        return None
+
+
 class UnionWithoutAll(Rule):
     """W011: UNION without ALL forces sort-and-dedupe."""
 

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -277,8 +277,8 @@ class GroupByOrdinal(Rule):
     name = "group-by-ordinal"
     severity = "warning"
     description = (
-        "GROUP BY by column position is non-portable and silently breaks if the "
-        "SELECT list is reordered"
+        "GROUP BY by column position silently breaks if the SELECT list is "
+        "reordered: a column insert or move changes which columns group"
     )
     multiline = True
 

--- a/tests/fixtures/warnings.sql
+++ b/tests/fixtures/warnings.sql
@@ -16,3 +16,8 @@ SELECT id FROM orders WHERE amount > 10000;
 SELECT id FROM orders_2024
 UNION
 SELECT id FROM orders_2025;
+
+-- W012: GROUP BY by ordinal
+SELECT region, status, COUNT(*)
+FROM orders
+GROUP BY 1, 2;

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -18,17 +18,17 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestRuleRegistry:
     def test_all_rules_loaded(self) -> None:
-        assert len(ALL_RULES) == 20
+        assert len(ALL_RULES) == 21
 
     def test_6_errors(self) -> None:
         errors = [r for r in ALL_RULES if r.severity == "error"]
         assert len(errors) == 6
 
-    def test_14_warnings(self) -> None:
-        # 11 "warning" (W-series) + 3 structural (S-series) all share the
+    def test_15_warnings(self) -> None:
+        # 12 "warning" (W-series) + 3 structural (S-series) all share the
         # "warning" severity in the registry.
         warnings = [r for r in ALL_RULES if r.severity == "warning"]
-        assert len(warnings) == 14
+        assert len(warnings) == 15
 
     def test_unique_ids(self) -> None:
         ids = [r.id for r in ALL_RULES]
@@ -127,6 +127,42 @@ class TestWarningRules:
 
         rule = UnionWithoutAll()
         statement = "SELECT id FROM orders_2024\nUNION ALL\nSELECT id FROM orders_2025;"
+        assert rule.check_statement(statement, 1, "test.sql") is None
+
+    def test_w012_group_by_ordinal(self) -> None:
+        findings = check([str(FIXTURES / "warnings.sql")])
+        w012 = [f for f in findings.findings if f.rule_id == "W012"]
+        assert len(w012) >= 1
+
+    def test_w012_catches_single_ordinal(self) -> None:
+        from sql_guard.rules.warnings import GroupByOrdinal
+
+        rule = GroupByOrdinal()
+        statement = "SELECT region, COUNT(*) FROM orders GROUP BY 1;"
+        assert rule.check_statement(statement, 1, "test.sql") is not None
+
+    def test_w012_catches_multiple_ordinals(self) -> None:
+        from sql_guard.rules.warnings import GroupByOrdinal
+
+        rule = GroupByOrdinal()
+        statement = "SELECT a, b, c, COUNT(*) FROM t GROUP BY 1, 2, 3;"
+        assert rule.check_statement(statement, 1, "test.sql") is not None
+
+    def test_w012_passes_on_explicit_columns(self) -> None:
+        from sql_guard.rules.warnings import GroupByOrdinal
+
+        rule = GroupByOrdinal()
+        statement = "SELECT region, status, COUNT(*) FROM orders GROUP BY region, status;"
+        assert rule.check_statement(statement, 1, "test.sql") is None
+
+    def test_w012_passes_on_digit_prefixed_column_name(self) -> None:
+        from sql_guard.rules.warnings import GroupByOrdinal
+
+        # Column names that start with a digit ('1st_quarter') are valid
+        # identifiers in dialects that quote them, and the regex must not
+        # match them because they are not pure integer tokens.
+        rule = GroupByOrdinal()
+        statement = "SELECT 1st_quarter, COUNT(*) FROM sales GROUP BY 1st_quarter;"
         assert rule.check_statement(statement, 1, "test.sql") is None
 
 


### PR DESCRIPTION
## Summary

Implements W012 (\`group-by-ordinal\`) per #2. Warns on \`GROUP BY\` that groups by positional column ordinal -- the grouping silently breaks the moment someone reorders the SELECT list.

## Should fail

\`\`\`sql
SELECT region, status, COUNT(*)
FROM orders
GROUP BY 1, 2;
\`\`\`

## Should pass

\`\`\`sql
SELECT region, status, COUNT(*)
FROM orders
GROUP BY region, status;
\`\`\`

## Implementation notes

- Single rule in \`sql_guard/rules/warnings.py\` wired into the registry.
- Severity: \`warning\` -- matches other \"brittle but not broken\" patterns (W001 \`SELECT *\`, W011 \`UNION\`).
- Regex: \`GROUP\s+BY\s+\d+\b(\s*,\s*\d+\b)*\`.
- Digit-prefixed identifiers like \`1st_quarter\` are safe: the trailing \`\b\` only matches if \`\d+\` is a pure integer token, so \`GROUP BY 1st_quarter\` does not fire. A dedicated test locks this in.
- Multiline rule, so it works for the common format where \`GROUP BY\` lives on its own line.

## Test plan

- [x] New fixture case in \`tests/fixtures/warnings.sql\` triggers W012
- [x] \`tests/test_rules.py\` adds 4 unit cases (single ordinal, multiple ordinals, explicit names pass, digit-prefixed identifier passes)
- [x] Registry counts updated (\`ALL_RULES\` goes 20 -> 21, warnings 14 -> 15)
- [x] Full suite: 64 passed, 1 skipped. The one pre-existing failure (\`test_structural.py::test_deep_nesting_detected\`) reproduces on \`main\` and is unrelated.

Fixes #2