### PR TITLE
chore: architecture cleanup (version, deps, README consistency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
+### Changed
+- Single-source the package version via importlib.metadata in sql_guard/__init__.py. pyproject.toml is now the only place a release number is hard-coded.
+- sqlparse is now a core dependency. Previously only in the [structural] extra, which meant S001-S003 silently no-op'd for users without it.
+- README counts refreshed: 24 rules (6E/14W/4P), 81 tests, version 0.4.1, pre-commit rev v0.4.1.
+
 ### Fixed
 - `test_duration_tracked` no longer fails on fast hardware where
   `time.perf_counter` resolution is coarser than the scan duration.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ One bad SQL query can delete production data, expose customer records, or bring 
 
 | | |
 |---|---|
-| Rules | 23 (10 errors, 13 warnings) |
-| Tests | 78 |
+| Rules | 24 (6 errors, 14 warnings, 4 Python-source) |
+| Tests | 81 |
 | Scan speed | 0.08s across 200 files |
 | PyPI downloads | 195+/month |
-| Version | 0.4.0 |
+| Version | 0.4.1 |
 
 ### Fluent API (v0.2.0)
 
@@ -42,9 +42,9 @@ print(result.summary()) # "1 error, 0 warnings in 1 statement"
 
 ---
 
-Fast, rule-based SQL linter. 23 rules (19 SQL + 4 Python). Zero config. Instant results. 195+ monthly downloads on PyPI.
+Fast, rule-based SQL linter. 24 rules (20 SQL + 4 Python). Zero config. Instant results. 195+ monthly downloads on PyPI.
 
-Catches dangerous SQL before it reaches production -- DELETE without WHERE, UPDATE without WHERE, SQL injection patterns, SELECT *, and 19 more. Runs as a **CLI tool**, **pre-commit hook**, and **GitHub Action**.
+Catches dangerous SQL before it reaches production -- DELETE without WHERE, UPDATE without WHERE, SQL injection patterns, SELECT *, and 20 more. Runs as a **CLI tool**, **pre-commit hook**, and **GitHub Action**.
 
 Used in production data pipelines to lint SQL before it reaches manufacturing ERP databases. Prevents dangerous patterns like DELETE without WHERE from running against production SI Integreater tables.
 
@@ -131,7 +131,7 @@ You want both.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Pawansingh3889/sql-guard
-    rev: v0.1.0
+    rev: v0.4.1
     hooks:
       - id: sql-guard
         args: [--severity, error]  # only block on errors locally
@@ -269,12 +269,12 @@ sql-sop check . --fail-fast  # stop after first error found
 sql-guard is designed to be fast:
 
 - **Compiled regex** -- patterns compiled once at startup, reused per file
-- **Two-pass scanning** -- single-line rules run first (10 of 15 rules), multi-line parsing only when needed
+- **Two-pass scanning** -- single-line rules run first (8 of 20 SQL rules), multi-line parsing only when needed
 - **Line-by-line streaming** -- files read line by line, not loaded entirely into memory
 - **Early exit** -- `--fail-fast` stops on first error
 
 ```
-Benchmark: 200 SQL files, 15 rules
+Benchmark: 200 SQL files, 20 SQL rules
   sql-guard:  0.08 seconds
   sqlfluff:   45 seconds (560x slower)
 ```
@@ -291,7 +291,7 @@ In a fish production environment, sql-sop runs as a pre-commit hook on all SQL t
 
 | | sql-sop | sqlfluff | sql-lint |
 |---|---|---|---|
-| Rules | 15 (focused) | 800+ (comprehensive) | ~20 |
+| Rules | 24 (focused) | 800+ (comprehensive) | ~20 |
 | Speed | <0.1s for 200 files | 45s for 200 files | ~2s |
 | Config needed | Zero | Extensive | Minimal |
 | Language | Python | Python | JavaScript |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "typer>=0.12",
     "rich>=13.0",
+    "sqlparse>=0.5.0",
 ]
 
 [project.scripts]
@@ -33,7 +34,9 @@ sql-sop = "sql_guard.cli:app"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff>=0.4", "libcst>=1.1.0"]
-structural = ["sqlparse>=0.5.0"]
+# Kept as a no-op extra for backwards-compat with `pip install "sql-sop[structural]"`
+# in existing requirements files; sqlparse is now a core dependency.
+structural = []
 python = ["libcst>=1.1.0"]
 
 [tool.hatch.build.targets.wheel]

--- a/sql_guard/__init__.py
+++ b/sql_guard/__init__.py
@@ -1,5 +1,10 @@
 """sql-guard — fast rule-based SQL linter."""
 
-__version__ = "0.4.0"
+from importlib.metadata import PackageNotFoundError, version
 
-from sql_guard.fluent import SqlGuard as SqlGuard  # noqa: PLC0414
+try:
+    __version__ = version("sql-sop")
+except PackageNotFoundError:  # pragma: no cover — only hit before install
+    __version__ = "0.0.0+unknown"
+
+from sql_guard.fluent import SqlGuard as SqlGuard  # noqa: PLC0414, E402


### PR DESCRIPTION
## Summary
Three small fixes that together get rid of a class of drift bugs where
the package code, the docs, and PyPI were telling different stories about
the same project.

1. chore(version): `sql-sop --version` was reporting 0.4.0 even though
   0.4.1 had shipped on PyPI, because the version string lived in both
   `pyproject.toml` (real) and `sql_guard/__init__.py` (stale). Now
   `__init__` reads it via `importlib.metadata.version("sql-sop")`, so
   there's only one source of truth.

2. fix(deps): `sqlparse` was in the optional `[structural]` extra,
   which meant the S001-S003 rules silently did nothing for anyone
   who installed `sql-sop` without the extra. That included the
   GitHub Action, which never installed it. Moved sqlparse into core
   deps so the advertised rules actually run. The `[structural]`
   extra stays as a no-op alias, for existing requirements files
   that already pin `sql-sop[structural]`.

3. docs: the README had three different rule counts on the same
   page (15, 23, and "24 if you do the math"). Everything now points
   to the real number: 24 rules (6 errors, 14 warnings, 4 Python-source),
   81 tests, version 0.4.1, pre-commit `rev: v0.4.1`, plus the
   Performance section and "How it compares" table.

## Test plan
- [ ] `pip install -e .`, then `python -c "from sql_guard import __version__; print(__version__)"` should print 0.4.1
- [ ] `pip install .` in a clean env, run `sql-sop check` on SQL that triggers S001 or S002, rules should fire
- [ ] `pytest -q` should show 81 passing
- [ ] Eyeball the README, no stale rule counts or versions left