### PR TITLE
warn on OVER ()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 - `test_duration_tracked` no longer fails on fast hardware where
   `time.perf_counter` resolution is coarser than the scan duration.
   Assertion relaxed from `> 0` to `>= 0` with an explicit float type check.
+- Added W013: warn on OVER() without ORDER BY / PARTITION BY to flag non-deterministic window 
+  functions.
 
 ## [0.4.1] - 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ sql-sop list-rules                       # show every registered rule
 | W008 | `mixed-case-keywords` | `select ... FROM` -- inconsistent casing |
 | W009 | `missing-semicolon` | Statement not terminated with `;` |
 | W010 | `commented-out-code` | `-- SELECT * FROM old_table` -- use version control |
+| W013 | `window-missing-order-partition` | `OVER ()` -- unpredictable results and unclear intent |
 
 ### Python scanning (v0.4.0+, opt-in)
 

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -23,6 +23,7 @@ from sql_guard.rules.warnings import (
     SubqueryCouldBeJoin,
     CommentedOutCode,
     UnionWithoutAll,
+    WindowMissingOrderPartition
 )
 from sql_guard.rules.structural import (
     DeeplyNestedSubquery,
@@ -50,6 +51,7 @@ ALL_RULES: list[Rule] = [
     MissingSemicolon(),
     CommentedOutCode(),
     UnionWithoutAll(),
+    WindowMissingOrderPartition(),
     # Structural (S001-S003)
     ImplicitCrossJoin(),
     DeeplyNestedSubquery(),

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -322,7 +322,7 @@ class WindowMissingOrderPartition(Rule):
                 severity=self.severity,
                 file=file,
                 line=start_line,
-                message=f"Missing ORDER BY / PARTITION BY in OVER clause",
+                message="Missing ORDER BY / PARTITION BY in OVER clause",
                 suggestion="Add ORDER BY for deterministic results and PARTITION BY to define window groups clearly",
             )
         return None

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -292,3 +292,37 @@ class UnionWithoutAll(Rule):
                 suggestion="Use UNION ALL if duplicate rows are impossible or undesired to remove",
             )
         return None
+
+
+class WindowMissingOrderPartition(Rule):
+    """W013: OVER() without ORDER BY / PARTITION BY can yield unpredictable results."""
+
+    id = "W013"
+    name = "window-missing-order-partition"
+    severity = "warning"
+    description = "OVER() without ORDER BY or PARTITION BY may lead to unpredictable results and unclear intent."
+    multiline = True
+
+    _over_pattern = Rule._compile(r"\bOVER\s*\(")
+    _valid_pattern = Rule._compile(r"OVER\s*\(\s*[^)]*(ORDER\s+BY|PARTITION\s+BY)[^)]*\)")
+
+    def has_valid_over_clause(self, statement: str) -> bool:
+        # If no OVER(...) clause → nothing to warn
+        if not self._over_pattern.search(statement):
+            return True
+
+        # Valid only if ORDER BY or PARTITION BY exists inside OVER(...)
+        return bool(self._valid_pattern.search(statement))
+    
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if not self.has_valid_over_clause(statement):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=start_line,
+                message=f"Missing ORDER BY / PARTITION BY in OVER clause",
+                suggestion="Add ORDER BY for deterministic results and PARTITION BY to define window groups clearly",
+            )
+        return None

--- a/tests/fixtures/warnings.sql
+++ b/tests/fixtures/warnings.sql
@@ -16,3 +16,10 @@ SELECT id FROM orders WHERE amount > 10000;
 SELECT id FROM orders_2024
 UNION
 SELECT id FROM orders_2025;
+
+-- W013: OVER without ORDER BY / PARTITION BY - failing case
+SELECT
+  user_id,
+  ROW_NUMBER() OVER () AS rn
+FROM events;
+

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -18,7 +18,7 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestRuleRegistry:
     def test_all_rules_loaded(self) -> None:
-        assert len(ALL_RULES) == 20
+        assert len(ALL_RULES) == 21
 
     def test_6_errors(self) -> None:
         errors = [r for r in ALL_RULES if r.severity == "error"]
@@ -28,7 +28,7 @@ class TestRuleRegistry:
         # 11 "warning" (W-series) + 3 structural (S-series) all share the
         # "warning" severity in the registry.
         warnings = [r for r in ALL_RULES if r.severity == "warning"]
-        assert len(warnings) == 14
+        assert len(warnings) == 15
 
     def test_unique_ids(self) -> None:
         ids = [r.id for r in ALL_RULES]
@@ -128,6 +128,11 @@ class TestWarningRules:
         rule = UnionWithoutAll()
         statement = "SELECT id FROM orders_2024\nUNION ALL\nSELECT id FROM orders_2025;"
         assert rule.check_statement(statement, 1, "test.sql") is None
+
+    def test_w013_window_missing_order_partition(self) -> None:
+        findings = check([str(FIXTURES / "warnings.sql")])
+        w013 = [f for f in findings.findings if f.rule_id == "W013"]
+        assert len(w013) >= 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for contributing to sql-sop! Fill out the sections below so the
maintainer doesn't have to ask. One-line docs fixes can skip most
sections; rule additions should fill everything.
-->

## What changed

<!-- One or two sentences explaining the *why*, not just the *what*. -->

## Related issue

<!-- "Closes #123" or "Relates to #123". -->

## If this adds or changes a rule

- [ ] Rule ID is the next unused one in its family (`E00N` / `W0NN` / `S00N` / `P00N`)
- [ ] Rule class registered in `sql_guard/rules/__init__.py`
- [ ] Fixture line in `tests/fixtures/errors.sql` or `warnings.sql`
- [ ] "Fires on bad SQL" test in `tests/test_rules.py`
- [ ] "Does NOT fire on safe SQL" test (using `tmp_path`)
- [ ] README rule table + Key Numbers count updated
- [ ] Rule is not a removal or rename of an existing rule (breaking change — see `GOVERNANCE.md`)

## Tests

- [ ] `pytest -q` passes
- [ ] `ruff check .` passes

## Checklist

- [ ] One logical change per commit, conventional commit style (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `test:`, `style:`)
- [ ] `CHANGELOG.md` `[Unreleased]` entry if user-facing

## Anything else reviewers should know
