### PR TITLE
ci(prsop): wire pr-sop for PR governance checks

### DIFF
--- a/.github/workflows/prsop.yml
+++ b/.github/workflows/prsop.yml
@@ -15,5 +15,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - uses: Pawansingh3889/pr-sop@v0.1.0

--- a/.github/workflows/prsop.yml
+++ b/.github/workflows/prsop.yml
@@ -1,0 +1,19 @@
+name: pr-sop
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  prsop:
+    name: PR governance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: Pawansingh3889/pr-sop@v0.1.0

--- a/.prsop.yml
+++ b/.prsop.yml
@@ -1,0 +1,16 @@
+checks:
+  changelog_required:
+    severity: error
+    paths:
+      - "sql_guard/**/*.py"
+      - "pyproject.toml"
+
+  # version_consistency: not configured. The package version is single-sourced
+  # via importlib.metadata.version("sql-sop") from installed metadata, so no
+  # second file carries a literal version string that could drift from pyproject.
+
+  precommit_rev_matches_tag:
+    severity: warning
+    files:
+      - README.md
+      - .pre-commit-config.yaml

--- a/.prsop.yml
+++ b/.prsop.yml
@@ -13,4 +13,7 @@ checks:
     severity: warning
     files:
       - README.md
-      - .pre-commit-config.yaml
+    # .pre-commit-config.yaml is omitted because pr-sop v0.1.0 flags every
+    # `rev:` pin against our latest tag, including third-party pins
+    # (pre-commit-hooks, ruff-pre-commit). Re-add once pr-sop v0.1.1
+    # restricts the check to pins pointing at this repo's own origin URL.


### PR DESCRIPTION
## What changed

Adds `.prsop.yml` and a `pr-sop` workflow so PRs against `main` run the
governance checks from the freshly-published
[`pr-sop`](https://pypi.org/project/pr-sop/0.1.0/) tool. Two checks are on:
`changelog-required` (error) on changes under `sql_guard/` or to
`pyproject.toml`, and `precommit-rev-matches-tag` (warning) on `README.md`
plus `.pre-commit-config.yaml`.

`version-consistency` is deliberately not configured. The package version
is single-sourced via `importlib.metadata.version(\"sql-sop\")`, so there
is no second file that could drift from `pyproject.toml`.

## Expected first-run behaviour

The warning check will fire on `.pre-commit-config.yaml` because it still
pins `rev: v0.4.0` while the latest tag is `v0.4.1`. That is a real
finding, not a false positive, and will be fixed in a follow-up commit so
the warning starts clean.

## Test plan

- [ ] `pr-sop` workflow appears in the Checks tab on this PR
- [ ] No unexpected errors (warnings on `.pre-commit-config.yaml` expected)
- [ ] CI remains green