### PR TITLE
ci(prsop): bump to v0.1.1 and re-enable .pre-commit-config.yaml check

### DIFF
--- a/.github/workflows/prsop.yml
+++ b/.github/workflows/prsop.yml
@@ -17,4 +17,4 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: Pawansingh3889/pr-sop@v0.1.0
+      - uses: Pawansingh3889/pr-sop@v0.1.1

--- a/.prsop.yml
+++ b/.prsop.yml
@@ -13,7 +13,4 @@ checks:
     severity: warning
     files:
       - README.md
-    # .pre-commit-config.yaml is omitted because pr-sop v0.1.0 flags every
-    # `rev:` pin against our latest tag, including third-party pins
-    # (pre-commit-hooks, ruff-pre-commit). Re-add once pr-sop v0.1.1
-    # restricts the check to pins pointing at this repo's own origin URL.
+      - .pre-commit-config.yaml


### PR DESCRIPTION
pr-sop v0.1.1 restricts precommit-rev-matches-tag to rev: pins whose surrounding repo: URL resolves to this repo via git origin. Third-party pins (pre-commit-hooks, ruff-pre-commit) no longer fire.

Two changes:

- Bump the workflow action to Pawansingh3889/pr-sop@v0.1.1
- Re-add .pre-commit-config.yaml to the precommit_rev_matches_tag files list

Expected first-run behaviour: one warning on .pre-commit-config.yaml line 31 (rev: v0.4.0 for the sql-guard self-hook, latest tag is v0.4.1). That is a real finding. Follow-up will bump the pin to v0.4.1, which is trivial but should not land in the same PR so this PR can demonstrate the check firing for real.