### PR TITLE
ci(prsop): bump to v0.1.2

### DIFF
--- a/.github/workflows/prsop.yml
+++ b/.github/workflows/prsop.yml
@@ -17,4 +17,4 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: Pawansingh3889/pr-sop@v0.1.1
+      - uses: Pawansingh3889/pr-sop@v0.1.2


### PR DESCRIPTION
pr-sop v0.1.2 fixes the precommit-rev-matches-tag check that was silently passing in Actions PR runs. The bug was that git describe --tags --abbrev=0 returns non-zero when the latest tag is not an ancestor of HEAD, which is common for the ephemeral merge commit GitHub creates for pull_request events. v0.1.2 switches to git tag --sort=-v:refname which works regardless of branch topology.

Expected first-run behaviour on this PR: one warning on .pre-commit-config.yaml line 31, since rev: v0.4.0 no longer matches the latest tag v0.4.1. That is the drift we wanted the check to catch all along.