### PR TITLE
feat: add T-SQL rules T001-T004 and FETCH NEXT pagination support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 ## [Unreleased]
 
 ### Added
+- **T001 `with-nolock`** - warns on `WITH (NOLOCK)` table hints. Causes
+  dirty reads. Commonly used as a performance band-aid instead of
+  fixing the underlying blocking (indexes, transaction scope, or
+  SNAPSHOT isolation).
+- **T002 `xp-cmdshell`** - errors on `EXEC xp_cmdshell`. Shell-execution
+  surface that should never appear in application SQL.
+- **T003 `cursor-declaration`** - warns on `DECLARE ... CURSOR`.
+  Row-by-row processing where set-based SQL usually does better.
+- **T004 `deprecated-outer-join`** - errors on `*=` and `=*` old-style
+  outer-join syntax. Deprecated in SQL Server 2005, unsupported in
+  SQL Server 2012 and later. Uses a negative lookbehind to avoid
+  matching modern compound-assignment expressions such as `SET @x *= 2`.
 - **W012 `group-by-ordinal`** - warns when `GROUP BY` uses positional
   ordinals (`GROUP BY 1, 2`) instead of explicit column names. Ordinal
   references are fragile to `SELECT` list reorders: inserting or
@@ -18,6 +30,9 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
   Explicit names are self-documenting and refactor-safe.
 
 ### Changed
+- W002 `missing-limit` and W006 `orderby-without-limit` now recognise
+  T-SQL's `OFFSET n ROWS FETCH NEXT m ROWS ONLY` pagination pattern as
+  a bounded query. Previously only `FETCH FIRST` was recognised.
 - Single-source the package version via importlib.metadata in sql_guard/__init__.py. pyproject.toml is now the only place a release number is hard-coded.
 - sqlparse is now a core dependency. Previously only in the [structural] extra, which meant S001-S003 silently no-op'd for users without it.
 - README counts refreshed: 24 rules (6E/14W/4P), 81 tests, version 0.4.1, pre-commit rev v0.4.1.

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -30,6 +30,12 @@ from sql_guard.rules.structural import (
     ImplicitCrossJoin,
     UnusedCTE,
 )
+from sql_guard.rules.tsql import (
+    CursorDeclaration,
+    DeprecatedOuterJoin,
+    WithNolock,
+    XpCmdshell,
+)
 
 ALL_RULES: list[Rule] = [
     # Errors (E001-E006)
@@ -56,6 +62,11 @@ ALL_RULES: list[Rule] = [
     ImplicitCrossJoin(),
     DeeplyNestedSubquery(),
     UnusedCTE(),
+    # T-SQL specific (T001-T004)
+    WithNolock(),
+    XpCmdshell(),
+    CursorDeclaration(),
+    DeprecatedOuterJoin(),
 ]
 
 

--- a/sql_guard/rules/tsql.py
+++ b/sql_guard/rules/tsql.py
@@ -1,0 +1,136 @@
+"""T-SQL-specific rules for SQL Server shops.
+
+These rules target anti-patterns that are SQL Server specific or most
+common in T-SQL stored-procedure codebases (manufacturing MES/ERP, legacy
+enterprise, SSRS datasets). They fire on text patterns that do not appear
+in BigQuery or Postgres code, so they can run unconditionally with near-
+zero false-positive rate on non-T-SQL input.
+
+See https://github.com/Pawansingh3889/sql-guard/issues/22 for scope.
+"""
+
+from __future__ import annotations
+
+from sql_guard.rules.base import Finding, Rule
+
+
+class WithNolock(Rule):
+    """T001: ``WITH (NOLOCK)`` hint allows dirty reads.
+
+    Common performance band-aid in T-SQL that silently permits reading
+    uncommitted data. Users should address the underlying blocking
+    (indexes, transaction scope, or SNAPSHOT isolation) instead.
+    """
+
+    id = "T001"
+    name = "with-nolock"
+    severity = "warning"
+    description = "WITH (NOLOCK) allows dirty reads; fix the underlying blocking"
+    multiline = False
+
+    _pattern = Rule._compile(r"\bWITH\s*\(\s*NOLOCK\s*\)")
+
+    def check_line(self, line: str, line_number: int, file: str) -> Finding | None:
+        if self._pattern.search(line):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=line_number,
+                message="WITH (NOLOCK) allows dirty reads",
+                suggestion="Use READ COMMITTED SNAPSHOT or fix the blocking instead",
+            )
+        return None
+
+
+class XpCmdshell(Rule):
+    """T002: ``xp_cmdshell`` executes OS-level commands.
+
+    Remote-code-execution surface. Should never appear in application
+    SQL. If you genuinely need it, it belongs in a locked-down DBA
+    runbook, not in a stored procedure.
+    """
+
+    id = "T002"
+    name = "xp-cmdshell"
+    severity = "error"
+    description = "xp_cmdshell executes arbitrary OS commands"
+    multiline = False
+
+    _pattern = Rule._compile(r"\bxp_cmdshell\b")
+
+    def check_line(self, line: str, line_number: int, file: str) -> Finding | None:
+        if self._pattern.search(line):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=line_number,
+                message="xp_cmdshell executes OS-level commands",
+                suggestion="Remove; shell exec should not appear in application SQL",
+            )
+        return None
+
+
+class CursorDeclaration(Rule):
+    """T003: ``DECLARE ... CURSOR`` is row-by-row processing.
+
+    Set-based SQL is usually orders of magnitude faster. Cursors are
+    legitimate for genuinely procedural work (admin scripts, one-offs)
+    but rarely belong in hot paths or stored procs called per request.
+    """
+
+    id = "T003"
+    name = "cursor-declaration"
+    severity = "warning"
+    description = "Cursor-based iteration is usually slower than set-based SQL"
+    multiline = False
+
+    _pattern = Rule._compile(r"\bDECLARE\s+\S+\s+CURSOR\b")
+
+    def check_line(self, line: str, line_number: int, file: str) -> Finding | None:
+        if self._pattern.search(line):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=line_number,
+                message="DECLARE ... CURSOR processes rows one at a time",
+                suggestion="Rewrite as set-based SQL where possible",
+            )
+        return None
+
+
+class DeprecatedOuterJoin(Rule):
+    """T004: ``*=`` and ``=*`` outer-join syntax.
+
+    Deprecated since SQL Server 2005, unsupported in SQL Server 2012 and
+    later (database compatibility level 90 or higher). Still appears in
+    legacy stored procs and migrated code.
+
+    Note: modern T-SQL also supports compound-assignment operators
+    (``SET @x *= 2``). The regex uses a negative lookbehind to avoid
+    matching ``@var *= expr`` as an outer join.
+    """
+
+    id = "T004"
+    name = "deprecated-outer-join"
+    severity = "error"
+    description = "Old-style *= / =* outer joins are unsupported in SQL Server 2012+"
+    multiline = True
+
+    _pattern = Rule._compile(r"(?<![@\w])\w+\s*(?:\*=|=\*)\s*\w+")
+
+    def check_statement(
+        self, statement: str, start_line: int, file: str
+    ) -> Finding | None:
+        if self._pattern.search(statement):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=start_line,
+                message="Deprecated *= or =* outer-join syntax",
+                suggestion="Use LEFT OUTER JOIN or RIGHT OUTER JOIN",
+            )
+        return None

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -39,7 +39,7 @@ class MissingLimit(Rule):
     multiline = True
 
     _select = Rule._compile(r"\bSELECT\b")
-    _limit = Rule._compile(r"\b(LIMIT|TOP|FETCH\s+FIRST)\b")
+    _limit = Rule._compile(r"\b(LIMIT|TOP|FETCH\s+(FIRST|NEXT))\b")
     _aggregate = Rule._compile(r"\b(COUNT|SUM|AVG|MIN|MAX|GROUP\s+BY)\b")
     _into = Rule._compile(r"\bINTO\b")
 
@@ -146,7 +146,7 @@ class OrderByWithoutLimit(Rule):
     multiline = True
 
     _orderby = Rule._compile(r"\bORDER\s+BY\b")
-    _limit = Rule._compile(r"\b(LIMIT|TOP|FETCH\s+FIRST)\b")
+    _limit = Rule._compile(r"\b(LIMIT|TOP|FETCH\s+(FIRST|NEXT))\b")
 
     def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
         if self._orderby.search(statement) and not self._limit.search(statement):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -18,17 +18,18 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestRuleRegistry:
     def test_all_rules_loaded(self) -> None:
-        assert len(ALL_RULES) == 21
+        assert len(ALL_RULES) == 25
 
-    def test_6_errors(self) -> None:
+    def test_8_errors(self) -> None:
+        # 6 E-series + 2 T-series (T002 xp-cmdshell, T004 deprecated-outer-join).
         errors = [r for r in ALL_RULES if r.severity == "error"]
-        assert len(errors) == 6
+        assert len(errors) == 8
 
-    def test_15_warnings(self) -> None:
-        # 12 "warning" (W-series) + 3 structural (S-series) all share the
-        # "warning" severity in the registry.
+    def test_17_warnings(self) -> None:
+        # 12 W-series + 3 S-series + 2 T-series (T001 with-nolock,
+        # T003 cursor-declaration) all share the "warning" severity.
         warnings = [r for r in ALL_RULES if r.severity == "warning"]
-        assert len(warnings) == 15
+        assert len(warnings) == 17
 
     def test_unique_ids(self) -> None:
         ids = [r.id for r in ALL_RULES]

--- a/tests/test_tsql.py
+++ b/tests/test_tsql.py
@@ -1,0 +1,143 @@
+"""Tests for T-SQL-specific rules (T001-T004)."""
+
+from __future__ import annotations
+
+from sql_guard.rules.tsql import (
+    CursorDeclaration,
+    DeprecatedOuterJoin,
+    WithNolock,
+    XpCmdshell,
+)
+from sql_guard.rules.warnings import MissingLimit, OrderByWithoutLimit
+
+
+def _check_line(rule, sql: str):
+    return rule.check_line(sql, 1, "test.sql")
+
+
+def _check_statement(rule, sql: str):
+    return rule.check_statement(sql, 1, "test.sql")
+
+
+# T001 with-nolock
+
+
+def test_t001_flags_basic_nolock():
+    rule = WithNolock()
+    finding = _check_line(rule, "SELECT * FROM orders WITH (NOLOCK)")
+    assert finding is not None
+    assert finding.rule_id == "T001"
+    assert finding.severity == "warning"
+
+
+def test_t001_flags_nolock_with_whitespace():
+    rule = WithNolock()
+    assert _check_line(rule, "SELECT * FROM orders WITH ( NOLOCK )") is not None
+
+
+def test_t001_case_insensitive():
+    rule = WithNolock()
+    assert _check_line(rule, "select * from t with (nolock)") is not None
+
+
+def test_t001_does_not_flag_with_cte():
+    rule = WithNolock()
+    assert _check_line(rule, "WITH cte AS (SELECT 1) SELECT * FROM cte") is None
+
+
+# T002 xp-cmdshell
+
+
+def test_t002_flags_xp_cmdshell():
+    rule = XpCmdshell()
+    finding = _check_line(rule, "EXEC xp_cmdshell 'dir C:\\'")
+    assert finding is not None
+    assert finding.rule_id == "T002"
+    assert finding.severity == "error"
+
+
+def test_t002_case_insensitive():
+    rule = XpCmdshell()
+    assert _check_line(rule, "EXEC XP_CMDSHELL 'whoami'") is not None
+
+
+def test_t002_does_not_flag_unrelated_procs():
+    rule = XpCmdshell()
+    assert _check_line(rule, "EXEC sp_executesql N'SELECT 1'") is None
+
+
+# T003 cursor-declaration
+
+
+def test_t003_flags_declare_cursor():
+    rule = CursorDeclaration()
+    finding = _check_line(rule, "DECLARE order_cursor CURSOR FOR SELECT id FROM orders")
+    assert finding is not None
+    assert finding.rule_id == "T003"
+    assert finding.severity == "warning"
+
+
+def test_t003_flags_declare_local_cursor():
+    rule = CursorDeclaration()
+    assert _check_line(rule, "DECLARE @c CURSOR") is not None
+
+
+def test_t003_does_not_flag_declare_variable():
+    rule = CursorDeclaration()
+    assert _check_line(rule, "DECLARE @i INT = 0") is None
+
+
+# T004 deprecated-outer-join
+
+
+def test_t004_flags_star_equals():
+    rule = DeprecatedOuterJoin()
+    finding = _check_statement(rule, "SELECT * FROM a, b WHERE a.id *= b.id")
+    assert finding is not None
+    assert finding.rule_id == "T004"
+    assert finding.severity == "error"
+
+
+def test_t004_flags_equals_star():
+    rule = DeprecatedOuterJoin()
+    assert _check_statement(rule, "SELECT * FROM a, b WHERE a.id =* b.id") is not None
+
+
+def test_t004_does_not_flag_compound_assignment():
+    rule = DeprecatedOuterJoin()
+    # @var *= expr is modern compound assignment, not an outer join.
+    assert _check_statement(rule, "SET @counter *= 2") is None
+
+
+def test_t004_does_not_flag_plain_assignment():
+    rule = DeprecatedOuterJoin()
+    assert _check_statement(rule, "SET @counter = 2") is None
+
+
+def test_t004_does_not_flag_modern_joins():
+    rule = DeprecatedOuterJoin()
+    assert (
+        _check_statement(rule, "SELECT * FROM a LEFT OUTER JOIN b ON a.id = b.id")
+        is None
+    )
+
+
+# W002 / W006 FETCH NEXT regression coverage
+
+
+def test_w002_accepts_tsql_fetch_next_pagination():
+    rule = MissingLimit()
+    sql = "SELECT id FROM orders ORDER BY id OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY"
+    assert _check_statement(rule, sql) is None
+
+
+def test_w006_accepts_tsql_fetch_next_pagination():
+    rule = OrderByWithoutLimit()
+    sql = "SELECT id FROM orders ORDER BY id OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY"
+    assert _check_statement(rule, sql) is None
+
+
+def test_w002_still_accepts_fetch_first():
+    rule = MissingLimit()
+    sql = "SELECT id FROM orders ORDER BY id FETCH FIRST 10 ROWS ONLY"
+    assert _check_statement(rule, sql) is None


### PR DESCRIPTION
Closes #22.

Adds four T-SQL-specific rules and a small regex tweak so T-SQL
pagination no longer trips the LIMIT-aware warnings.

## New rules

- **T001 `with-nolock`** (warning). Flags `WITH (NOLOCK)` table hints.
  Causes dirty reads.
- **T002 `xp-cmdshell`** (error). Flags `EXEC xp_cmdshell`. Shell-exec
  surface that should never appear in application SQL.
- **T003 `cursor-declaration`** (warning). Flags `DECLARE ... CURSOR`.
  Row-by-row processing where set-based SQL usually does better.
- **T004 `deprecated-outer-join`** (error). Flags `*=` and `=*` old-style
  outer-join syntax. Unsupported in SQL Server 2012 and later. Uses a
  negative lookbehind to avoid matching modern compound-assignment
  expressions like `SET @x *= 2`.

## Regex tweak

W002 `missing-limit` and W006 `orderby-without-limit` now match
`FETCH\s+(FIRST|NEXT)` instead of only `FETCH\s+FIRST`, so T-SQL's
`OFFSET n ROWS FETCH NEXT m ROWS ONLY` pagination counts as bounded.

## Scope notes

The originally proposed `old-style-join` rule is already covered by
S001 `ImplicitCrossJoin`, so dropped to avoid duplicate findings.

Version bump, README rule-count refresh, and `.pre-commit-config.yaml`
rev update are intentionally left for a release-prep PR so
`precommit_rev_matches_tag` does not complain about a tag that does
not yet exist.

## Tests

18 new tests in `tests/test_tsql.py` covering each rule's positive
and negative cases, including:

- T001 flags all whitespace variants and case, ignores `WITH cte AS`.
- T002 flags `xp_cmdshell` case-insensitively, ignores `sp_executesql`.
- T003 flags cursor declarations, ignores `DECLARE @i INT`.
- T004 flags `*=` and `=*`, ignores compound assignment, plain
  assignment, and modern JOIN syntax.
- W002 and W006 accept both `FETCH FIRST` (existing) and
  `FETCH NEXT` (new) T-SQL pagination.

Full suite: 80 passed, 1 skipped.
