### PR TITLE
chore: release v0.5.0 with T-SQL rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   # Runs sql-sop on the project's own fixtures + any staged .sql files
   # so a regression in a rule is caught before it ships.
   - repo: https://github.com/Pawansingh3889/sql-guard
-    rev: v0.4.0
+    rev: v0.5.0
     hooks:
       - id: sql-sop
         args: [--severity, error]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-20
+
 ### Added
 - **T001 `with-nolock`** - warns on `WITH (NOLOCK)` table hints. Causes
   dirty reads. Commonly used as a performance band-aid instead of
@@ -35,7 +37,7 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
   a bounded query. Previously only `FETCH FIRST` was recognised.
 - Single-source the package version via importlib.metadata in sql_guard/__init__.py. pyproject.toml is now the only place a release number is hard-coded.
 - sqlparse is now a core dependency. Previously only in the [structural] extra, which meant S001-S003 silently no-op'd for users without it.
-- README counts refreshed: 24 rules (6E/14W/4P), 81 tests, version 0.4.1, pre-commit rev v0.4.1.
+- README counts refreshed: 29 rules (6E/12W/3S/4T/4P), version 0.5.0, pre-commit rev v0.5.0.
 
 ### Fixed
 - `test_duration_tracked` no longer fails on fast hardware where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
+_Nothing queued. See [0.5.0] for the most recent release._
+
 ## [0.5.0] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ print(result.summary()) # "1 error, 0 warnings in 1 statement"
 
 ---
 
-Fast, rule-based SQL linter. 24 rules (20 SQL + 4 Python). Zero config. Instant results. 195+ monthly downloads on PyPI.
+Fast, rule-based SQL linter. 29 rules (25 SQL + 4 Python), including 4 T-SQL-specific rules for SQL Server shops. Zero config. Instant results. 195+ monthly downloads on PyPI.
 
 Catches dangerous SQL before it reaches production -- DELETE without WHERE, UPDATE without WHERE, SQL injection patterns, SELECT *, and 20 more. Runs as a **CLI tool**, **pre-commit hook**, and **GitHub Action**.
 
@@ -131,7 +131,7 @@ You want both.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Pawansingh3889/sql-guard
-    rev: v0.4.1
+    rev: v0.5.0
     hooks:
       - id: sql-guard
         args: [--severity, error]  # only block on errors locally
@@ -223,6 +223,20 @@ sql-sop list-rules                       # show every registered rule
 | W008 | `mixed-case-keywords` | `select ... FROM` -- inconsistent casing |
 | W009 | `missing-semicolon` | Statement not terminated with `;` |
 | W010 | `commented-out-code` | `-- SELECT * FROM old_table` -- use version control |
+
+### T-SQL (v0.5.0+)
+
+Rules targeting SQL Server anti-patterns common in legacy stored procs
+and SSRS datasets. Fire on text patterns that do not appear in BigQuery
+or Postgres code, so they run unconditionally with near-zero false
+positives on non-T-SQL input.
+
+| ID | Name | What it catches |
+|---|---|---|
+| T001 | `with-nolock` | `SELECT * FROM t WITH (NOLOCK)` -- dirty reads |
+| T002 | `xp-cmdshell` | `EXEC xp_cmdshell ...` -- shell-exec surface |
+| T003 | `cursor-declaration` | `DECLARE c CURSOR FOR ...` -- row-by-row processing |
+| T004 | `deprecated-outer-join` | `WHERE a.x *= b.y` -- removed in SQL Server 2012+ |
 
 ### Python scanning (v0.4.0+, opt-in)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sql-sop"
-version = "0.4.1"
+version = "0.5.0"
 description = "Fast rule-based SQL linter. Pre-commit hook + GitHub Action + CLI."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release prep for v0.5.0, bundling the T-SQL rules merged in #23.

## What

- `pyproject.toml` version 0.4.1 → 0.5.0.
- `README.md` hero line and rules table refreshed: 29 rules (25 SQL +
  4 Python), new T-SQL section added with T001-T004.
- `README.md` pre-commit hook example bumped to `rev: v0.5.0`.
- `.pre-commit-config.yaml` self-reference bumped from v0.4.0 to v0.5.0,
  closing the drift that pr-sop's `precommit_rev_matches_tag` has been
  warning on since v0.4.1.
- `CHANGELOG.md` [Unreleased] section rotated to [0.5.0] with today's
  date.

## Sequencing

pr-sop's `precommit_rev_matches_tag` check compares self-rev pins to
the latest git tag. On this PR the refs say v0.5.0 but the latest tag
is still v0.4.1, so the check will warn (severity warning in
`.prsop.yml`, non-blocking). After merge, tagging v0.5.0 resolves the
mismatch and subsequent PRs will be clean.

## After merge

1. `git tag v0.5.0 && git push origin v0.5.0`
2. `release.yml` trusted-publish workflow uploads sdist/wheel to PyPI
   as sql-sop 0.5.0 and creates the GitHub release.
