### PR TITLE
feat(rules): add P005 sqlalchemy-text-fstring rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
-_Nothing queued. See [0.5.0] for the most recent release._
+### Added
+- **P005 `sqlalchemy-text-fstring`** - errors on `sqlalchemy.text(f"...{var}")`.
+  Same SQL-injection hazard P001 catches for `cursor.execute()`, but on the
+  `sqlalchemy.text()` surface. P001 now skips `text()` call sites so P005
+  handles them with a sqlalchemy-specific message and suggestion
+  (mirrors the existing P004 `call_name != "text"` guard).
+  ([#10](https://github.com/Pawansingh3889/sql-guard/issues/10))
 
 ## [0.5.0] - 2026-04-20
 

--- a/sql_guard/rules/python_rules.py
+++ b/sql_guard/rules/python_rules.py
@@ -1,4 +1,4 @@
-"""Python-only SQL hazards (P001-P004).
+"""Python-only SQL hazards (P001-P005).
 
 These rules fire on SQL strings reached from Python source via the libCST
 scanner. They complement the regex-based E/W/S rules: those look at SQL
@@ -42,7 +42,9 @@ class FStringInExecute(PythonRule):
         )
 
     def check(self, hit: ExtractedSql, file: str) -> Finding | None:
-        if hit.kind == "fstring" and hit.call_name:
+        # sqlalchemy.text(f"...") is handled by the more specific P005 rule
+        # (SqlalchemyTextFstring). Skip here to avoid double-firing.
+        if hit.kind == "fstring" and hit.call_name and hit.call_name != "text":
             return Finding(
                 rule_id=self.id,
                 severity=self.severity,
@@ -127,9 +129,36 @@ class BareVariableInExecute(PythonRule):
         return None
 
 
+class SqlalchemyTextFstring(PythonRule):
+    """P005: f-string wrapped in ``sqlalchemy.text(...)`` re-introduces SQL injection."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            id="P005",
+            name="sqlalchemy-text-fstring",
+            severity="error",
+            description="f-string passed to sqlalchemy.text() -- SQL injection risk",
+        )
+
+    def check(self, hit: ExtractedSql, file: str) -> Finding | None:
+        if hit.kind == "fstring" and hit.call_name == "text":
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=hit.line,
+                message="f-string passed to sqlalchemy.text() -- SQL injection risk",
+                suggestion=(
+                    "Use bound parameters: text(\"... WHERE id = :id\"), {\"id\": user_id}"
+                ),
+            )
+        return None
+
+
 PYTHON_RULES: list[PythonRule] = [
     FStringInExecute(),
     ConcatInExecute(),
     FormatInExecute(),
     BareVariableInExecute(),
+    SqlalchemyTextFstring(),
 ]

--- a/tests/fixtures/python_hazards.py
+++ b/tests/fixtures/python_hazards.py
@@ -54,3 +54,10 @@ def safe_sqlalchemy(connection, user_id: int):
 def variable_assigned_raw():
     sql = "DELETE FROM staging"  # reachable via SQL_VARIABLE_NAMES
     return sql
+
+
+def unsafe_sqlalchemy_text_fstring(connection, user_id):
+    # P005 - f-string wrapped in sqlalchemy.text()
+    from sqlalchemy import text
+
+    return connection.execute(text(f"SELECT * FROM users WHERE id = {user_id}"))

--- a/tests/test_python_scanner.py
+++ b/tests/test_python_scanner.py
@@ -102,17 +102,8 @@ class TestPythonRules:
     def test_p001_skips_text_to_avoid_double_firing_with_p005(self) -> None:
         # When the f-string target is sqlalchemy.text(), only P005 should
         # fire -- P001 skips that case to avoid duplicate findings on the
-        # same line.
-        f = self._findings()
-        text_line_findings = [
-            x for x in f
-            if "WHERE id = {user_id}" in (x.message or "")
-            or ("text" in (x.message or "") and "f-string" in (x.message or ""))
-        ]
-        # We should have at most one rule firing per sqlalchemy.text(f"...")
-        # line; if both P001 and P005 both hit for the same line, that is a
-        # duplicate.
-        for finding in f:
+        # same line. Assert P001 never names text() in its messages.
+        for finding in self._findings():
             if finding.rule_id == "P001":
                 assert "text()" not in finding.message, (
                     "P001 should not fire on text() calls -- P005 handles those"

--- a/tests/test_python_scanner.py
+++ b/tests/test_python_scanner.py
@@ -60,7 +60,7 @@ class TestScanner:
 
 
 # ---------------------------------------------------------------------------
-# Python-only rules (P001-P004)
+# Python-only rules (P001-P005)
 # ---------------------------------------------------------------------------
 
 
@@ -91,6 +91,32 @@ class TestPythonRules:
         f = self._findings()
         p004 = [x for x in f if x.rule_id == "P004"]
         assert p004 and all(x.severity == "warning" for x in p004)
+
+    def test_p005_sqlalchemy_text_fstring_flagged(self) -> None:
+        f = self._findings()
+        p005 = [x for x in f if x.rule_id == "P005"]
+        assert p005, "P005 should fire on text(f'...')"
+        assert all(x.severity == "error" for x in p005)
+        assert any("sqlalchemy.text()" in x.message for x in p005)
+
+    def test_p001_skips_text_to_avoid_double_firing_with_p005(self) -> None:
+        # When the f-string target is sqlalchemy.text(), only P005 should
+        # fire -- P001 skips that case to avoid duplicate findings on the
+        # same line.
+        f = self._findings()
+        text_line_findings = [
+            x for x in f
+            if "WHERE id = {user_id}" in (x.message or "")
+            or ("text" in (x.message or "") and "f-string" in (x.message or ""))
+        ]
+        # We should have at most one rule firing per sqlalchemy.text(f"...")
+        # line; if both P001 and P005 both hit for the same line, that is a
+        # duplicate.
+        for finding in f:
+            if finding.rule_id == "P001":
+                assert "text()" not in finding.message, (
+                    "P001 should not fire on text() calls -- P005 handles those"
+                )
 
     def test_safe_parameterised_produces_no_p_findings(self) -> None:
         # The safe_parameterised function uses a literal SQL with a tuple
@@ -144,4 +170,4 @@ class TestDiscoveryAndCheck:
     def test_check_with_include_python_surfaces_p_rules(self) -> None:
         result = check([str(FIXTURES)], include_python=True)
         ids = {f.rule_id for f in result.findings}
-        assert {"P001", "P002", "P003", "P004"}.issubset(ids)
+        assert {"P001", "P002", "P003", "P004", "P005"}.issubset(ids)


### PR DESCRIPTION
## Summary

Closes #10. Adds rule **P005 `sqlalchemy-text-fstring`**, which catches `sqlalchemy.text(f"...{var}")` -- the same SQL-injection hazard P001 catches for `cursor.execute()`, but on the sqlalchemy.text() surface.

```python
from sqlalchemy import text

# Flagged: P005 (error)
conn.execute(text(f"SELECT * FROM users WHERE id = {user_id}"))

# OK:
conn.execute(
    text("SELECT * FROM users WHERE id = :id"),
    {"id": user_id},
)
```

## Why this matters

`sqlalchemy.text()` is the documented escape hatch for raw SQL in SQLAlchemy. Wrapping an f-string inside it defeats parameter binding and re-introduces the exact SQL-injection risk that P001-P004 catch on `cursor.execute()`. "text" was already registered in the scanner's `EXECUTE_METHODS` frozenset, so P001 silently fired on these cases with a generic `.text()` message; P005 replaces that with a sqlalchemy-specific message and suggestion so the warning lands correctly for the reader.

## Changes

- `sql_guard/rules/python_rules.py`: new `SqlalchemyTextFstring` class (P005) checking `hit.kind == "fstring" and hit.call_name == "text"`; added to `PYTHON_RULES`. Severity `error`, matches P001 + what the issue asked for.
- `sql_guard/rules/python_rules.py`: P001's `FStringInExecute.check` now skips when `call_name == "text"`. This mirrors the existing P004 pattern (`BareVariableInExecute` already has `call_name != "text"` in its guard) and prevents P001+P005 double-firing on the same line.
- `tests/fixtures/python_hazards.py`: new `unsafe_sqlalchemy_text_fstring` function as the fixture for P005.
- `tests/test_python_scanner.py`: new `test_p005_sqlalchemy_text_fstring_flagged` (severity + message check), `test_p001_skips_text_to_avoid_double_firing_with_p005` (regression guard), and the end-to-end `test_check_with_include_python_surfaces_p_rules` now asserts `P005` is in the surfaced rule ID set.
- Docstring header in `python_rules.py` bumped from "P001-P004" to "P001-P005".

## Testing

- `pytest tests/test_python_scanner.py -v`: 23 passed, including the 3 new P005-related tests.
- `pytest -q` (full suite): 106 passed.
- `ruff check sql_guard/ tests/`: clean (caught an unused local during self-review, now removed).

## Implementation notes

The issue said to "Model after P001 fstring-in-execute"; this PR does that structurally (same class shape, same `check` signature, same severity). The one extra change beyond a plain clone is the P001 skip-on-`text` guard, which keeps the findings output clean for `sqlalchemy.text(f"...")` callers -- one P005 finding per site, not a P001+P005 pair.

Estimated LOC in the issue: ~30 code + ~25 test. Actual: ~22 code + ~20 test (matches the estimate closely).

---

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
