### PR TITLE
feat(rules): add W016 not-in-with-subquery rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
-_Nothing queued. See [0.5.0] for the most recent release._
+### Added
+- **W016 `not-in-with-subquery`** - warns on `WHERE col NOT IN (SELECT ...)`.
+  When the subquery returns any `NULL`, the predicate evaluates to `UNKNOWN`
+  for every outer row and the query silently returns zero results. Suggests
+  `NOT EXISTS` or `LEFT JOIN ... WHERE ... IS NULL` instead.
 
 ## [0.5.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ sql-sop list-rules                       # show every registered rule
 | W008 | `mixed-case-keywords` | `select ... FROM` -- inconsistent casing |
 | W009 | `missing-semicolon` | Statement not terminated with `;` |
 | W010 | `commented-out-code` | `-- SELECT * FROM old_table` -- use version control |
+| W016 | `not-in-with-subquery` | `WHERE id NOT IN (SELECT ...)` -- silently returns 0 rows on NULL |
 
 ### T-SQL (v0.5.0+)
 

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -12,6 +12,7 @@ from sql_guard.rules.errors import (
     UpdateWithoutWhere,
 )
 from sql_guard.rules.warnings import (
+    CommentedOutCode,
     FunctionOnIndexedColumn,
     GroupByOrdinal,
     HardcodedValues,
@@ -19,10 +20,10 @@ from sql_guard.rules.warnings import (
     MissingSemicolon,
     MissingTableAlias,
     MixedCaseKeywords,
+    NotInWithSubquery,
     OrderByWithoutLimit,
     SelectStar,
     SubqueryCouldBeJoin,
-    CommentedOutCode,
     UnionWithoutAll,
 )
 from sql_guard.rules.structural import (
@@ -45,7 +46,7 @@ ALL_RULES: list[Rule] = [
     StringConcatInWhere(),
     InsertWithoutColumns(),
     UpdateWithoutWhere(),
-    # Warnings (W001-W012)
+    # Warnings (W001-W012, W016)
     SelectStar(),
     MissingLimit(),
     FunctionOnIndexedColumn(),
@@ -58,6 +59,7 @@ ALL_RULES: list[Rule] = [
     CommentedOutCode(),
     UnionWithoutAll(),
     GroupByOrdinal(),
+    NotInWithSubquery(),
     # Structural (S001-S003)
     ImplicitCrossJoin(),
     DeeplyNestedSubquery(),

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -322,3 +322,27 @@ class UnionWithoutAll(Rule):
                 suggestion="Use UNION ALL if duplicate rows are impossible or undesired to remove",
             )
         return None
+
+
+class NotInWithSubquery(Rule):
+    """W016: NOT IN with subquery silently returns zero rows on NULL."""
+
+    id = "W016"
+    name = "not-in-with-subquery"
+    severity = "warning"
+    description = "NOT IN with subquery returns zero rows if subquery contains NULL"
+    multiline = True
+
+    _pattern = Rule._compile(r"\bNOT\s+IN\s*\(\s*SELECT\b")
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if self._pattern.search(statement):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=start_line,
+                message="NOT IN with subquery -- returns zero rows if subquery has NULL",
+                suggestion="Use NOT EXISTS or LEFT JOIN ... WHERE ... IS NULL instead",
+            )
+        return None

--- a/tests/fixtures/warnings.sql
+++ b/tests/fixtures/warnings.sql
@@ -21,3 +21,8 @@ SELECT id FROM orders_2025;
 SELECT region, status, COUNT(*)
 FROM orders
 GROUP BY 1, 2;
+
+-- W016: NOT IN with subquery
+SELECT *
+FROM customers
+WHERE id NOT IN (SELECT customer_id FROM orders);

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -18,18 +18,18 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestRuleRegistry:
     def test_all_rules_loaded(self) -> None:
-        assert len(ALL_RULES) == 25
+        assert len(ALL_RULES) == 26
 
     def test_8_errors(self) -> None:
         # 6 E-series + 2 T-series (T002 xp-cmdshell, T004 deprecated-outer-join).
         errors = [r for r in ALL_RULES if r.severity == "error"]
         assert len(errors) == 8
 
-    def test_17_warnings(self) -> None:
-        # 12 W-series + 3 S-series + 2 T-series (T001 with-nolock,
+    def test_18_warnings(self) -> None:
+        # 13 W-series + 3 S-series + 2 T-series (T001 with-nolock,
         # T003 cursor-declaration) all share the "warning" severity.
         warnings = [r for r in ALL_RULES if r.severity == "warning"]
-        assert len(warnings) == 17
+        assert len(warnings) == 18
 
     def test_unique_ids(self) -> None:
         ids = [r.id for r in ALL_RULES]
@@ -165,6 +165,20 @@ class TestWarningRules:
         rule = GroupByOrdinal()
         statement = "SELECT 1st_quarter, COUNT(*) FROM sales GROUP BY 1st_quarter;"
         assert rule.check_statement(statement, 1, "test.sql") is None
+
+    def test_w016_not_in_with_subquery(self) -> None:
+        findings = check([str(FIXTURES / "warnings.sql")])
+        w016 = [f for f in findings.findings if f.rule_id == "W016"]
+        assert len(w016) >= 1
+        assert "NOT IN" in w016[0].message
+
+    def test_w016_not_in_value_list_ok(self, tmp_path) -> None:
+        # NOT IN (1, 2, 3) value list must NOT trigger -- only subqueries.
+        sql = tmp_path / "value_list.sql"
+        sql.write_text("SELECT id FROM users WHERE status_id NOT IN (1, 2, 3);\n")
+        result = check([str(sql)])
+        w016 = [f for f in result.findings if f.rule_id == "W016"]
+        assert not w016
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Adds a new warning rule **W016 `not-in-with-subquery`** that catches `WHERE col NOT IN (SELECT ...)`. When the subquery returns any `NULL`, the predicate evaluates to `UNKNOWN` for every outer row and the query silently returns zero results. This is the bug described in issue #6 (the regex and acceptance examples come straight from the issue body).

## Related issue

Closes #6

## If this adds or changes a rule

- [x] Rule ID is the next unused one in its family — `W016` (not used elsewhere; verified via `grep -rn '"W016"' sql_guard/rules`)
- [x] Rule class registered in `sql_guard/rules/__init__.py` (`NotInWithSubquery` added to imports + `ALL_RULES`, comment updated to `W001-W012, W016`)
- [x] Fixture line in `tests/fixtures/warnings.sql` (the canonical `customers NOT IN (SELECT customer_id FROM orders)` example from the issue)
- [x] "Fires on bad SQL" test in `tests/test_rules.py` (`test_w016_not_in_with_subquery` runs against the fixture)
- [x] "Does NOT fire on safe SQL" test using `tmp_path` (`test_w016_not_in_value_list_ok` confirms `NOT IN (1, 2, 3)` value lists are not flagged)
- [x] README rule table updated (added `W016` row to the warnings table after `W010`). Key Numbers block left as-is since it's already a release behind (says 24 rules / 14 warnings / version 0.4.1 while v0.5.0 is on `main` with 25 rules); fixing that drift seemed out of scope here.
- [x] Not a removal or rename

## Tests

- [x] `python3 -m pytest tests/test_rules.py -q` -> `32 passed in 0.02s` (the two new W016 tests included)
- [x] `ruff check sql_guard/rules/warnings.py sql_guard/rules/__init__.py tests/test_rules.py` -> `All checks passed!`

The full `pytest tests/` run shows one pre-existing failure in `tests/test_structural.py::TestDeeplyNestedSubquery::test_deep_nesting_detected` that reproduces on `upstream/main` (`a507f00`) before this branch — confirmed by checking out main and running the single test in isolation. Not introduced by this change.

## Checklist

- [x] One logical change per commit, conventional commit style (`feat(rules): ...`)
- [x] `CHANGELOG.md` `[Unreleased]` entry added under `### Added`

## Anything else reviewers should know

The rule uses `multiline = True` + `check_statement` because the issue's footgun pattern naturally spans lines (a real-world `NOT IN (SELECT ...)` typically has the subquery on its own line). The chosen regex matches the issue's `r"\bNOT\s+IN\s*\(\s*SELECT\b"` exactly, which means it won't trigger on value lists like `NOT IN (1, 2, 3)` — that case is asserted by `test_w016_not_in_value_list_ok`.

This contribution was developed with AI assistance (Codex).
