### PR TITLE
feat(rules): add W019 count-distinct-unbounded rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
+### Added
+- **W019 `count-distinct-unbounded`** - warns on `COUNT(DISTINCT col)`
+  with no `WHERE`, `GROUP BY`, or `LIMIT` restricting the scope. Forces
+  a full sort + distinct pass over the entire table, a frequent perf
+  surprise on prod. Resolves #7.
+
 ## [0.6.0] - 2026-04-26
 
 ### Added

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -15,6 +15,7 @@ from sql_guard.rules.errors import (
 )
 from sql_guard.rules.warnings import (
     CommentedOutCode,
+    CountDistinctUnbounded,
     FunctionOnIndexedColumn,
     GroupByOrdinal,
     HardcodedValues,
@@ -71,6 +72,7 @@ ALL_RULES: list[Rule] = [
     LeadingWildcardLike(),
     OrAcrossColumns(),
     TruncateTable(),
+    CountDistinctUnbounded(),
     # Structural (S001-S003)
     ImplicitCrossJoin(),
     DeeplyNestedSubquery(),

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -443,3 +443,42 @@ class TruncateTable(Rule):
                 suggestion="Use DELETE if triggers or partial rollback matter",
             )
         return None
+
+
+class CountDistinctUnbounded(Rule):
+    """W019: ``COUNT(DISTINCT col)`` on an unfiltered table.
+
+    ``COUNT(DISTINCT col)`` forces a full sort + distinct pass over the
+    rows it sees. On a large unfiltered table that's a frequent perf
+    surprise on prod. The rule fires when the same statement has neither
+    a ``WHERE`` clause nor a ``GROUP BY`` (which already partitions the
+    work) nor a ``LIMIT`` restricting the scope.
+    """
+
+    id = "W019"
+    name = "count-distinct-unbounded"
+    severity = "warning"
+    description = "COUNT(DISTINCT) without WHERE/GROUP BY/LIMIT scans the whole table"
+    multiline = True
+
+    _count_distinct = Rule._compile(r"\bCOUNT\s*\(\s*DISTINCT\b")
+    _where = Rule._compile(r"\bWHERE\b")
+    _group_by = Rule._compile(r"\bGROUP\s+BY\b")
+    _limit = Rule._compile(r"\b(LIMIT|TOP|FETCH\s+(FIRST|NEXT))\b")
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if (
+            self._count_distinct.search(statement)
+            and not self._where.search(statement)
+            and not self._group_by.search(statement)
+            and not self._limit.search(statement)
+        ):
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=start_line,
+                message="COUNT(DISTINCT) without WHERE/GROUP BY -- full table sort + distinct",
+                suggestion="Add a WHERE/LIMIT to restrict scope, or pre-aggregate with GROUP BY",
+            )
+        return None

--- a/tests/test_new_rules.py
+++ b/tests/test_new_rules.py
@@ -1,10 +1,11 @@
-"""Tests for v0.6.0 rules: E007, E008, W017, W018, W020, T005."""
+"""Tests for v0.6.0 rules + W019."""
 
 from __future__ import annotations
 
 from sql_guard.rules.errors import AlterAddNotNullNoDefault, DropColumn
 from sql_guard.rules.tsql import CreateIndexWithoutOnline
 from sql_guard.rules.warnings import (
+    CountDistinctUnbounded,
     LeadingWildcardLike,
     OrAcrossColumns,
     TruncateTable,
@@ -140,3 +141,57 @@ def test_t005_flags_clustered_unique_variants():
         rule,
         "CREATE UNIQUE NONCLUSTERED INDEX ix ON orders (id);",
     ) is not None
+
+
+# W019 count-distinct-unbounded -----------------------------------------------
+
+
+def test_w019_flags_count_distinct_without_filter():
+    rule = CountDistinctUnbounded()
+    finding = _stmt(rule, "SELECT COUNT(DISTINCT user_id) FROM events;")
+    assert finding is not None
+    assert finding.rule_id == "W019"
+    assert finding.severity == "warning"
+
+
+def test_w019_passes_with_where():
+    rule = CountDistinctUnbounded()
+    assert (
+        _stmt(
+            rule,
+            "SELECT COUNT(DISTINCT user_id) FROM events WHERE event_date >= '2024-01-01';",
+        )
+        is None
+    )
+
+
+def test_w019_passes_with_group_by():
+    rule = CountDistinctUnbounded()
+    assert (
+        _stmt(
+            rule,
+            "SELECT tenant_id, COUNT(DISTINCT user_id) FROM events GROUP BY tenant_id;",
+        )
+        is None
+    )
+
+
+def test_w019_passes_with_limit():
+    rule = CountDistinctUnbounded()
+    assert (
+        _stmt(rule, "SELECT COUNT(DISTINCT user_id) FROM events LIMIT 1;")
+        is None
+    )
+
+
+def test_w019_handles_whitespace_in_count_distinct():
+    rule = CountDistinctUnbounded()
+    finding = _stmt(rule, "SELECT COUNT (  DISTINCT  user_id) FROM events;")
+    assert finding is not None
+    assert finding.rule_id == "W019"
+
+
+def test_w019_does_not_fire_on_plain_count():
+    rule = CountDistinctUnbounded()
+    assert _stmt(rule, "SELECT COUNT(*) FROM events;") is None
+    assert _stmt(rule, "SELECT COUNT(user_id) FROM events;") is None

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -18,18 +18,18 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestRuleRegistry:
     def test_all_rules_loaded(self) -> None:
-        assert len(ALL_RULES) == 32
+        assert len(ALL_RULES) == 33
 
     def test_10_errors(self) -> None:
         # 8 E-series + 2 T-series (T002 xp-cmdshell, T004 deprecated-outer-join).
         errors = [r for r in ALL_RULES if r.severity == "error"]
         assert len(errors) == 10
 
-    def test_22_warnings(self) -> None:
-        # 16 W-series + 3 S-series + 3 T-series (T001 with-nolock,
+    def test_23_warnings(self) -> None:
+        # 17 W-series + 3 S-series + 3 T-series (T001 with-nolock,
         # T003 cursor-declaration, T005 create-index-without-online).
         warnings = [r for r in ALL_RULES if r.severity == "warning"]
-        assert len(warnings) == 22
+        assert len(warnings) == 23
 
     def test_unique_ids(self) -> None:
         ids = [r.id for r in ALL_RULES]


### PR DESCRIPTION
Resolves #7.

> The issue title pre-dates v0.6.0; W017 is now `leading-wildcard-like`. This rule lands as **W019**, the next free ID before W020.

Warns on `COUNT(DISTINCT col)` without `WHERE`, `GROUP BY`, or `LIMIT` in the same statement. That pattern forces the engine into a full sort + distinct pass over the whole table, which is the perf surprise the issue flags.

## Behaviour

| SQL | Verdict |
| --- | --- |
| `SELECT COUNT(DISTINCT user_id) FROM events;` | fires |
| `SELECT COUNT(DISTINCT user_id) FROM events WHERE event_date >= '2024-01-01';` | passes |
| `SELECT tenant_id, COUNT(DISTINCT user_id) FROM events GROUP BY tenant_id;` | passes |
| `SELECT COUNT(DISTINCT user_id) FROM events LIMIT 1;` | passes |
| `SELECT COUNT(*) FROM events;` / `SELECT COUNT(user_id) FROM events;` | not flagged |

Whitespace inside the call (`COUNT (  DISTINCT  user_id)`) is tolerated.

## Tests

6 new cases in `tests/test_new_rules.py` covering the matrix above, plus the registry-count tests in `tests/test_rules.py` were bumped from 22 -> 23 warnings (32 -> 33 total). `pytest tests/` is 127 passed, 1 skipped.