### PR TITLE
feat(rules): add W023 scalar-udf-in-where

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
+### Added
+
+- W023 `scalar-udf-in-where`: warns on `<schema>.<name>(...)` calls in
+  `WHERE`/`HAVING`/`ON` clauses, the canonical T-SQL scalar-UDF
+  anti-pattern. Built-ins (no schema prefix) are unaffected.
+  ([#30](https://github.com/Pawansingh3889/sql-guard/issues/30))
+
 ## [0.6.2] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ One bad SQL query can delete production data, expose customer records, or bring 
 
 | | |
 |---|---|
-| Rules | 39 (10 errors, 24 warnings, 5 Python-source) |
+| Rules | 40 (10 errors, 25 warnings, 5 Python-source) |
 | Tests | 152 |
 | Coverage | 86% |
 | Scan speed | 0.08s across 200 files |
@@ -43,7 +43,7 @@ print(result.summary()) # "1 error, 0 warnings in 1 statement"
 
 ---
 
-Fast, rule-based SQL linter. 38 rules (33 SQL + 5 Python), including 5 T-SQL-specific rules for SQL Server shops. Inline disable, project config, git-changed-only mode, and SARIF output for GitHub Code Scanning. 500+ monthly downloads on PyPI.
+Fast, rule-based SQL linter. 40 rules (35 SQL + 5 Python), including SQL Server-focused rules for T-SQL shops. Inline disable, project config, git-changed-only mode, and SARIF output for GitHub Code Scanning. 500+ monthly downloads on PyPI.
 
 Catches dangerous SQL before it reaches production -- DELETE without WHERE, UPDATE without WHERE, SQL injection patterns, SELECT *, and 20 more. Runs as a **CLI tool**, **pre-commit hook**, and **GitHub Action**.
 
@@ -231,6 +231,7 @@ sql-sop list-rules                       # show every registered rule
 | W017 | `leading-wildcard-like` | `WHERE name LIKE '%smith'` -- non-SARGable, full scan |
 | W018 | `or-across-columns` | `WHERE a = 1 OR b = 2` -- defeats single-column indexes |
 | W020 | `truncate-table` | `TRUNCATE TABLE staging;` -- bypasses triggers, resets identity |
+| W023 | `scalar-udf-in-where` | `WHERE dbo.fn_X(col) = 1` -- row-by-row predicate evaluation |
 
 
 ### T-SQL (v0.5.0+)
@@ -440,6 +441,7 @@ Thank you to the people who have shipped rules and code to sql-sop.
 | [@tmchow](https://github.com/tmchow) | [W011 `union-without-all`](https://github.com/Pawansingh3889/sql-guard/pull/12). Flags `UNION` where `UNION ALL` would be safe and faster. |
 | [@tmchow](https://github.com/tmchow) | [P005 `sqlalchemy-text-fstring`](https://github.com/Pawansingh3889/sql-guard/pull/25). Catches `sqlalchemy.text(f"...{var}")` patterns that defeat parameter binding. |
 | [@mvanhorn](https://github.com/mvanhorn) | [W019 `count-distinct-unbounded`](https://github.com/Pawansingh3889/sql-guard/pull/29). Flags `COUNT(DISTINCT col)` without WHERE, GROUP BY, or LIMIT. |
+| [@mvanhorn](https://github.com/mvanhorn) | W023 `scalar-udf-in-where`. Flags schema-qualified scalar UDF calls inside WHERE, HAVING, and ON predicates. |
 | [@Prabhu-1409](https://github.com/Prabhu-1409) | [W013 `window-without-partition`](https://github.com/Pawansingh3889/sql-guard/pull/21). Flags `OVER ()` without `PARTITION BY`, dialect-aware messaging for Postgres and Redshift. |
 
 See [the full contributors graph](https://github.com/Pawansingh3889/sql-guard/graphs/contributors) on GitHub.

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -27,6 +27,7 @@ from sql_guard.rules.warnings import (
     NotInWithSubquery,
     OrAcrossColumns,
     OrderByWithoutLimit,
+    ScalarUdfInWhere,
     SelectStar,
     SubqueryCouldBeJoin,
     TruncateTable,
@@ -75,6 +76,7 @@ ALL_RULES: list[Rule] = [
     OrAcrossColumns(),
     TruncateTable(),
     CountDistinctUnbounded(),
+    ScalarUdfInWhere(),
     # Structural (S001-S003)
     ImplicitCrossJoin(),
     DeeplyNestedSubquery(),

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -1,4 +1,4 @@
-"""Warning rules (W001-W020) -- advisory, don't block commits by default."""
+"""Warning rules (W001-W023) -- advisory, don't block commits by default."""
 
 from __future__ import annotations
 
@@ -514,4 +514,44 @@ class WindowMissingPartition(Rule):
                 message="Missing PARTITION BY in OVER clause",
                 suggestion="Add PARTITION BY to define window groups clearly",
             )
+        return None
+
+
+class ScalarUdfInWhere(Rule):
+    """W023: T-SQL scalar UDF in WHERE/HAVING/ON predicate.
+
+    Scalar UDFs in predicate positions force row-by-row evaluation
+    and prevent index seeks. Built-ins (LEN, UPPER, SUBSTRING, etc.)
+    are not affected because they lack a schema prefix.
+    """
+
+    id = "W023"
+    name = "scalar-udf-in-where"
+    severity = "warning"
+    description = "Scalar UDF in WHERE/HAVING/ON forces row-by-row evaluation"
+    multiline = True
+
+    _predicate_clause = Rule._compile(
+        r"\b(?:WHERE|HAVING|ON)\b([\s\S]*?)"
+        r"(?=\bGROUP\s+BY\b|\bORDER\s+BY\b|\bHAVING\b|\bUNION\b|"
+        r"\bEXCEPT\b|\bINTERSECT\b|\bLIMIT\b|\bFETCH\b|;|\Z)"
+    )
+    _schema_dotted_call = Rule._compile(
+        r"\b[A-Za-z_][A-Za-z0-9_]*\s*\.\s*[A-Za-z_][A-Za-z0-9_]*\s*\("
+    )
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        for clause_match in self._predicate_clause.finditer(statement):
+            clause_body = clause_match.group(1)
+            if self._schema_dotted_call.search(clause_body):
+                return Finding(
+                    rule_id=self.id,
+                    severity=self.severity,
+                    file=file,
+                    line=start_line,
+                    message="Scalar UDF in predicate forces row-by-row evaluation",
+                    suggestion=(
+                        "Inline the predicate, or use an inline TVF (CROSS APPLY) instead"
+                    ),
+                )
         return None

--- a/tests/fixtures/warnings.sql
+++ b/tests/fixtures/warnings.sql
@@ -34,3 +34,8 @@ FROM events;
 SELECT *
 FROM customers
 WHERE id NOT IN (SELECT customer_id FROM orders);
+
+-- W023: scalar UDF in WHERE
+SELECT order_id, total
+FROM orders
+WHERE dbo.fn_IsHighValue(total) = 1;

--- a/tests/test_new_rules.py
+++ b/tests/test_new_rules.py
@@ -8,6 +8,7 @@ from sql_guard.rules.warnings import (
     CountDistinctUnbounded,
     LeadingWildcardLike,
     OrAcrossColumns,
+    ScalarUdfInWhere,
     TruncateTable,
 )
 
@@ -195,3 +196,82 @@ def test_w019_does_not_fire_on_plain_count():
     rule = CountDistinctUnbounded()
     assert _stmt(rule, "SELECT COUNT(*) FROM events;") is None
     assert _stmt(rule, "SELECT COUNT(user_id) FROM events;") is None
+
+
+# W023 scalar-udf-in-where ----------------------------------------------------
+
+
+def test_w023_flags_dbo_udf_in_where():
+    rule = ScalarUdfInWhere()
+    finding = _stmt(
+        rule,
+        "SELECT order_id FROM orders WHERE dbo.fn_IsHighValue(total) = 1;",
+    )
+    assert finding is not None
+    assert finding.rule_id == "W023"
+    assert finding.severity == "warning"
+
+
+def test_w023_flags_schema_udf_in_where():
+    rule = ScalarUdfInWhere()
+    finding = _stmt(
+        rule,
+        "SELECT id FROM t WHERE myschema.fn_X(col) = 1;",
+    )
+    assert finding is not None
+    assert finding.rule_id == "W023"
+
+
+def test_w023_passes_len_builtin_in_where():
+    rule = ScalarUdfInWhere()
+    assert _stmt(rule, "SELECT id FROM users WHERE LEN(name) > 5;") is None
+
+
+def test_w023_passes_upper_builtin_in_where():
+    rule = ScalarUdfInWhere()
+    assert _stmt(rule, "SELECT id FROM users WHERE UPPER(name) = 'X';") is None
+
+
+def test_w023_passes_udf_in_select_list_only():
+    rule = ScalarUdfInWhere()
+    assert _stmt(rule, "SELECT dbo.fn_X(col) FROM t WHERE id = 1;") is None
+
+
+def test_w023_flags_udf_in_having():
+    rule = ScalarUdfInWhere()
+    finding = _stmt(
+        rule,
+        "SELECT col, COUNT(*) FROM t GROUP BY col HAVING dbo.fn_X(col) > 0;",
+    )
+    assert finding is not None
+    assert finding.rule_id == "W023"
+
+
+def test_w023_flags_udf_in_join_on():
+    rule = ScalarUdfInWhere()
+    finding = _stmt(
+        rule,
+        "SELECT a.id FROM a JOIN b ON dbo.fn_X(a.id) = b.id;",
+    )
+    assert finding is not None
+    assert finding.rule_id == "W023"
+
+
+def test_w023_flags_inner_where_in_exists():
+    rule = ScalarUdfInWhere()
+    finding = _stmt(
+        rule,
+        "SELECT id FROM t WHERE EXISTS (SELECT 1 FROM x WHERE dbo.fn_X(col) = 1);",
+    )
+    assert finding is not None
+    assert finding.rule_id == "W023"
+
+
+def test_w023_passes_plain_where():
+    rule = ScalarUdfInWhere()
+    assert _stmt(rule, "SELECT id FROM orders WHERE total > 1000;") is None
+
+
+def test_w023_passes_table_column_reference():
+    rule = ScalarUdfInWhere()
+    assert _stmt(rule, "SELECT id FROM t WHERE x.y = 1;") is None

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -18,7 +18,7 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestRuleRegistry:
     def test_all_rules_loaded(self) -> None:
-        assert len(ALL_RULES) == 34
+        assert len(ALL_RULES) == 35
 
     def test_10_errors(self) -> None:
         # 8 E-series + 2 T-series (T002 xp-cmdshell, T004 deprecated-outer-join).
@@ -26,10 +26,10 @@ class TestRuleRegistry:
         assert len(errors) == 10
 
     def test_24_warnings(self) -> None:
-        # 18 W-series + 3 S-series + 3 T-series (T001 with-nolock,
+        # 19 W-series + 3 S-series + 3 T-series (T001 with-nolock,
         # T003 cursor-declaration, T005 create-index-without-online).
         warnings = [r for r in ALL_RULES if r.severity == "warning"]
-        assert len(warnings) == 24
+        assert len(warnings) == 25
 
     def test_unique_ids(self) -> None:
         ids = [r.id for r in ALL_RULES]


### PR DESCRIPTION
## Summary

Closes #30. Part of the [v0.7 Performance Rules Pack](https://github.com/Pawansingh3889/sql-guard/milestone/1).

Adds **W023 `scalar-udf-in-where`**, mirroring W019 / `CountDistinctUnbounded` in shape and test layout (the issue itself points at W019 as the canonical reference).

## What it catches

```sql
-- Fires
SELECT order_id FROM orders WHERE dbo.fn_IsHighValue(total) = 1;

-- Does NOT fire (built-in, no schema prefix)
SELECT order_id FROM orders WHERE LEN(name) > 5;
```

The rule extracts WHERE / HAVING / ON predicate bodies and looks for any `<schema>.<name>(` call inside them. The schema-prefix requirement is the key heuristic: built-ins do not carry a `dbo.` / `<schema>.` prefix in T-SQL, so `LEN`, `UPPER`, `SUBSTRING`, `CONVERT`, `YEAR`, etc. naturally don't match. SELECT-list calls don't match either because the clause-body extraction excludes them.

## Edge cases covered (per the issue + tests)

- Built-in functions in WHERE: `LEN`, `UPPER`, `SUBSTRING` -- no fire (no schema prefix).
- Schema-qualified UDF in SELECT list only -- no fire (extracted from WHERE/HAVING/ON only).
- `EXISTS (... WHERE dbo.fn_X(col) = 1)` correlated subquery -- fires on inner WHERE.
- `HAVING dbo.fn_X(col) > 0` -- fires.
- `JOIN b ON dbo.fn_X(a.id) = b.id` -- fires.
- `WHERE x.y = 1` (table.column reference) -- no fire (the regex requires a trailing `(`).

## Files

- `sql_guard/rules/warnings.py`: `ScalarUdfInWhere` class.
- `sql_guard/rules/__init__.py`: import + `ALL_RULES` registration.
- `tests/test_new_rules.py`: 10 new tests covering positive + negative cases.
- `tests/fixtures/warnings.sql`: W023 fixture line.
- `tests/test_rules.py`: bumped `test_all_rules_loaded` (34 -> 35) and `test_24_warnings` (24 -> 25).
- `README.md`: rule table row + contributors entry update.
- `CHANGELOG.md`: `### Added` line under `[Unreleased]`.

## Verification

- `pytest tests/test_new_rules.py -k w023` -- 10 passed.
- `pytest tests/test_rules.py -k "all_rules_loaded or 24_warnings"` -- 2 passed.
- The existing `test_deep_nesting_detected` failure in `tests/test_structural.py` is pre-existing on `main` (verified by stashing my changes) and unrelated to this PR.

## Out of scope

- Postgres `VOLATILE` function detection (the issue notes this as v0.8).
- T-prefix re-coding to `T006` if the maintainer prefers T-SQL-only rules to use a `T` prefix; happy to rename in a follow-up.
- Detecting UDFs without a schema prefix (bare `MyFunc(col)`). T-SQL convention is to prefix them; tracking the trade-off in the issue's edge-case 1 + 2 discussion.