### PR TITLE
feat: contracts pack (C001-C005) + schema-snapshot + validate-contract subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
   `-- sql-guard: disable=W022` on the same line. Contributed by
   [@vibeyclaw](https://github.com/vibeyclaw)
   ([#31](https://github.com/Pawansingh3889/sql-guard/pull/31)).
+- **Contract Rules pack (C001-C004)** - new `--contract path.yml` flag
+  loads a data contract describing the expected schema and lints SQL
+  against it. Without a contract the rules are silent, so the addition
+  is fully backwards-compatible. The contract format is a thin subset
+  of the [open data-contract space](https://github.com/datacontract/datacontract-cli):
+  tables -> columns -> type / not_null / primary_key / foreign_key /
+  has_default. Contract path can also be supplied via `contract:` in
+  `.sql-guard.yml`, resolved relative to the config file.
+  - **C001 `column-not-in-contract`** (warning): SQL references a column
+    that isn't declared in the contract for that table.
+  - **C002 `table-not-in-contract`** (warning): statement touches a table
+    not declared in the contract. Disable for partial-coverage contracts.
+  - **C003 `not-null-violation`** (error): INSERT omits a column that the
+    contract marks as NOT NULL with no default.
+  - **C004 `primary-key-missing-on-insert`** (error): INSERT omits a
+    primary-key column that has no default in the contract.
 - W023 `scalar-udf-in-where`: warns on `<schema>.<name>(...)` calls in
   `WHERE`/`HAVING`/`ON` clauses, the canonical T-SQL scalar-UDF
   anti-pattern. Built-ins (no schema prefix) are unaffected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
   `-- sql-guard: disable=W022` on the same line. Contributed by
   [@vibeyclaw](https://github.com/vibeyclaw)
   ([#31](https://github.com/Pawansingh3889/sql-guard/pull/31)).
-- **Contract Rules pack (C001-C004)** - new `--contract path.yml` flag
+- **Contract Rules pack (C001-C005)** - new `--contract path.yml` flag
   loads a data contract describing the expected schema and lints SQL
   against it. Without a contract the rules are silent, so the addition
   is fully backwards-compatible. The contract format is a thin subset
@@ -52,6 +52,24 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
     contract marks as NOT NULL with no default.
   - **C004 `primary-key-missing-on-insert`** (error): INSERT omits a
     primary-key column that has no default in the contract.
+  - **C005 `unmapped-fk`** (warning): JOIN predicate uses two columns the
+    contract has no foreign-key relationship for. Catches accidental
+    cross-table joins where the schema declares no relationship between
+    the two columns. Resolves the FK in either direction so the JOIN
+    column order doesn't matter.
+- **`sql-sop schema-snapshot --dsn ... --output contract.yml`** - new
+  subcommand. Connects to a live database via SQLAlchemy, introspects
+  tables / columns / PKs / FKs / nullable, and writes a contract-shaped
+  YAML. Bootstraps the contract workflow: take a snapshot of an existing
+  database, commit it as `contract.yml`, then lint queries against it
+  via `--contract`. Requires `pip install "sql-sop[snapshot]"`. Supports
+  `--schema` (override default schema) and `--include-table` (repeatable,
+  for partial snapshots).
+- **`sql-sop validate-contract --contract contract.yml`** - new
+  subcommand. Loads the contract, validates structure, prints
+  table/column/PK/FK counts, exits non-zero on parse failure. Useful in
+  CI before `check --contract` so a malformed contract fails fast with a
+  readable error rather than an obscure check-time crash.
 - W023 `scalar-udf-in-where`: warns on `<schema>.<name>(...)` calls in
   `WHERE`/`HAVING`/`ON` clauses, the canonical T-SQL scalar-UDF
   anti-pattern. Built-ins (no schema prefix) are unaffected.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,21 @@ positives on non-T-SQL input.
 | T004 | `deprecated-outer-join` | `WHERE a.x *= b.y` -- removed in SQL Server 2012+ |
 | T005 | `create-index-without-online` | `CREATE INDEX ix ON t (...)` -- locks table; add `WITH (ONLINE = ON)` |
 
+### Contracts (opt-in via `--contract`)
+
+Pass `--contract path/to/contract.yml` (or set `contract:` in
+`.sql-guard.yml`) to lint queries against the expected schema. Without a
+contract these rules are silent. Format is a thin subset of the open
+data-contract space; see `tests/fixtures/contract_sample.yml` for a
+working example.
+
+| ID | Name | What it catches |
+|---|---|---|
+| C001 | `column-not-in-contract` | `SELECT o.bogus FROM orders o` -- column not declared for that table |
+| C002 | `table-not-in-contract` | `SELECT * FROM ghost_table` -- table absent from the contract |
+| C003 | `not-null-violation` | `INSERT INTO orders (id) VALUES (1)` -- omits a NOT NULL column |
+| C004 | `primary-key-missing-on-insert` | INSERT omits a PK column with no default |
+
 ### Python scanning (v0.4.0+, opt-in)
 
 Enable with `pip install "sql-sop[python]"` and `--include-python`. Uses

--- a/README.md
+++ b/README.md
@@ -266,6 +266,19 @@ working example.
 | C002 | `table-not-in-contract` | `SELECT * FROM ghost_table` -- table absent from the contract |
 | C003 | `not-null-violation` | `INSERT INTO orders (id) VALUES (1)` -- omits a NOT NULL column |
 | C004 | `primary-key-missing-on-insert` | INSERT omits a PK column with no default |
+| C005 | `unmapped-fk` | `JOIN ... ON o.id = c.id` -- columns have no FK relationship in the contract |
+
+Two helper subcommands round out the workflow:
+
+```bash
+# Bootstrap a contract from an existing database (requires sql-sop[snapshot]):
+sql-sop schema-snapshot \
+  --dsn "mssql+pyodbc://user:pass@host/db?driver=ODBC+Driver+18+for+SQL+Server" \
+  --output contract.yml
+
+# Validate a contract YAML structure before running rules (CI-friendly):
+sql-sop validate-contract --contract contract.yml
+```
 
 ### Python scanning (v0.4.0+, opt-in)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,13 @@ dependencies = [
 sql-sop = "sql_guard.cli:app"
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "libcst>=1.1.0"]
+dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.4", "libcst>=1.1.0", "sqlalchemy>=2.0"]
 # Kept as a no-op extra for backwards-compat with `pip install "sql-sop[structural]"`
 # in existing requirements files; sqlparse is now a core dependency.
 structural = []
 python = ["libcst>=1.1.0"]
+# `schema-snapshot` introspects a live database via SQLAlchemy.
+snapshot = ["sqlalchemy>=2.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["sql_guard"]

--- a/sql_guard/checker.py
+++ b/sql_guard/checker.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from sql_guard.contracts import Contract
 from sql_guard.rules import get_rules
 from sql_guard.rules.base import Finding, Rule
 from sql_guard.rules.python_rules import PYTHON_RULES
@@ -249,6 +250,7 @@ def check(
     disabled_rules: set[str] | None = None,
     ignore: list[str] | None = None,
     include_python: bool = False,
+    contract: Contract | None = None,
 ) -> CheckResult:
     """Run all rules against discovered SQL (and optionally Python) files.
 
@@ -259,12 +261,14 @@ def check(
         disabled_rules: Set of rule IDs to skip.
         ignore: Path patterns to ignore.
         include_python: Also scan ``.py`` files for embedded SQL via libCST.
+        contract: Optional data contract. When provided, contract-aware rules
+            (C001-...) are activated and given this contract instance.
 
     Returns:
         CheckResult with all findings.
     """
     t0 = time.perf_counter()
-    rules = get_rules(disabled_ids=disabled_rules)
+    rules = get_rules(disabled_ids=disabled_rules, contract=contract)
     discovered = discover_files(paths, ignore=ignore, include_python=include_python)
 
     result = CheckResult()

--- a/sql_guard/cli.py
+++ b/sql_guard/cli.py
@@ -16,7 +16,7 @@ from sql_guard.contracts import Contract
 from sql_guard.git_filter import filter_to_changed
 from sql_guard.reporters import sarif as sarif_reporter
 from sql_guard.reporters.terminal import print_result
-from sql_guard.rules import ALL_RULES, CONTRACT_RULE_CLASSES
+from sql_guard.rules import ALL_RULES
 from sql_guard.rules.python_rules import PYTHON_RULES
 
 app = typer.Typer(

--- a/sql_guard/cli.py
+++ b/sql_guard/cli.py
@@ -12,10 +12,11 @@ from rich.table import Table
 
 from sql_guard import __version__, config as config_mod
 from sql_guard.checker import check, discover_files
+from sql_guard.contracts import Contract
 from sql_guard.git_filter import filter_to_changed
 from sql_guard.reporters import sarif as sarif_reporter
 from sql_guard.reporters.terminal import print_result
-from sql_guard.rules import ALL_RULES
+from sql_guard.rules import ALL_RULES, CONTRACT_RULE_CLASSES
 from sql_guard.rules.python_rules import PYTHON_RULES
 
 app = typer.Typer(
@@ -65,6 +66,14 @@ def check_cmd(
         "-o",
         help="Write report to this file instead of stdout (sarif format only).",
     ),
+    contract_path: Optional[Path] = typer.Option(
+        None,
+        "--contract",
+        help=(
+            "Path to a data-contract YAML. When set, contract rules (C001-) "
+            "lint queries against the declared schema."
+        ),
+    ),
 ) -> None:
     """Check SQL files for common issues."""
     if not paths:
@@ -80,6 +89,22 @@ def check_cmd(
 
     effective_include_python = include_python or cfg.include_python
     effective_ignore = cfg.ignore or None
+
+    contract: Optional[Contract] = None
+    effective_contract_path = contract_path or cfg.contract
+    if effective_contract_path is not None:
+        try:
+            contract = Contract.from_file(effective_contract_path)
+        except FileNotFoundError:
+            console.print(
+                f"[red]Contract file not found:[/red] {effective_contract_path}"
+            )
+            raise typer.Exit(code=2)
+        except Exception as exc:
+            console.print(
+                f"[red]Failed to load contract {effective_contract_path}:[/red] {exc}"
+            )
+            raise typer.Exit(code=2)
 
     if changed_only:
         discovered = discover_files(
@@ -104,6 +129,7 @@ def check_cmd(
         disabled_rules=disabled or None,
         ignore=effective_ignore,
         include_python=effective_include_python,
+        contract=contract,
     )
 
     if output_format == "sarif":

--- a/sql_guard/cli.py
+++ b/sql_guard/cli.py
@@ -167,6 +167,108 @@ def list_rules() -> None:
     console.print(table)
 
 
+@app.command("validate-contract")
+def validate_contract_cmd(
+    contract_path: Path = typer.Option(
+        ...,
+        "--contract",
+        help="Path to a data-contract YAML to validate.",
+    ),
+) -> None:
+    """Validate a data-contract YAML's structure without running rules.
+
+    Useful in CI before ``check --contract``: a malformed contract fails
+    fast with a clear error message instead of an obscure check-time
+    crash.
+    """
+    if not contract_path.is_file():
+        console.print(f"[red]Contract file not found:[/red] {contract_path}")
+        raise typer.Exit(code=2)
+    try:
+        contract = Contract.from_file(contract_path)
+    except Exception as exc:  # pragma: no cover - exact YAML errors vary by version
+        console.print(f"[red]Invalid contract:[/red] {exc}")
+        raise typer.Exit(code=2)
+
+    table_count = len(contract.tables)
+    if table_count == 0:
+        console.print(
+            f"[yellow]Loaded {contract_path} but no tables were declared. "
+            "The contract has no effect.[/yellow]"
+        )
+        return
+
+    column_count = sum(len(t.columns) for t in contract.tables.values())
+    pk_count = sum(len(t.primary_keys) for t in contract.tables.values())
+    fk_count = sum(
+        1
+        for t in contract.tables.values()
+        for c in t.columns.values()
+        if c.foreign_key
+    )
+
+    console.print(
+        f"[green]OK[/green] {contract_path}: {table_count} tables, "
+        f"{column_count} columns, {pk_count} primary keys, {fk_count} foreign keys."
+    )
+
+
+@app.command("schema-snapshot")
+def schema_snapshot_cmd(
+    dsn: str = typer.Option(
+        ...,
+        "--dsn",
+        help=(
+            "SQLAlchemy connection string, e.g. "
+            "'mssql+pyodbc://user:pass@host/db?driver=ODBC+Driver+18+for+SQL+Server' "
+            "or 'postgresql://user:pass@host/db'."
+        ),
+    ),
+    output_path: Path = typer.Option(
+        Path("contract.yml"),
+        "--output",
+        "-o",
+        help="Where to write the contract YAML (default: ./contract.yml).",
+    ),
+    schema: Optional[str] = typer.Option(
+        None,
+        "--schema",
+        help="Schema name (default: the dialect default, e.g. dbo / public).",
+    ),
+    include_table: Optional[list[str]] = typer.Option(
+        None,
+        "--include-table",
+        help="Restrict the snapshot to these tables. Repeatable.",
+    ),
+) -> None:
+    """Connect to a database and write a contract YAML describing its schema.
+
+    Bootstraps the contract workflow: take a snapshot of an existing
+    database, commit it as ``contract.yml``, then lint queries against
+    it via ``--contract contract.yml``. Requires the ``[snapshot]``
+    extra: ``pip install "sql-sop[snapshot]"``.
+    """
+    from sql_guard import snapshot as snapshot_mod
+
+    try:
+        data = snapshot_mod.introspect(
+            dsn=dsn, schema=schema, include_tables=include_table
+        )
+    except snapshot_mod.SnapshotError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=2)
+    except Exception as exc:
+        console.print(f"[red]Snapshot failed:[/red] {exc}")
+        raise typer.Exit(code=2)
+
+    snapshot_mod.write_snapshot(data, output_path)
+
+    table_count = len(data.get("tables") or {})
+    console.print(
+        f"[green]OK[/green] wrote {output_path} with {table_count} tables."
+    )
+
+
 @app.command()
 def version() -> None:
     """Show version."""

--- a/sql_guard/config.py
+++ b/sql_guard/config.py
@@ -41,15 +41,27 @@ class Config:
     ignore: list[str] = field(default_factory=list)
     include_python: bool = False
     severity: str = "warning"
+    contract: Path | None = None
     source: Path | None = None
 
     @classmethod
     def from_dict(cls, data: dict, source: Path | None = None) -> "Config":
+        contract_value = data.get("contract")
+        contract_path: Path | None = None
+        if contract_value:
+            raw_path = Path(str(contract_value))
+            # Resolve contract paths relative to the config file when
+            # supplied, so a project-root config can reference
+            # ``schema/contract.yml`` without fully-qualified paths.
+            if not raw_path.is_absolute() and source is not None:
+                raw_path = source.parent / raw_path
+            contract_path = raw_path
         return cls(
             disable={s.upper() for s in (data.get("disable") or [])},
             ignore=list(data.get("ignore") or []),
             include_python=bool(data.get("include_python", False)),
             severity=str(data.get("severity") or "warning"),
+            contract=contract_path,
             source=source,
         )
 

--- a/sql_guard/contracts.py
+++ b/sql_guard/contracts.py
@@ -1,0 +1,111 @@
+"""Data contract loader and types.
+
+A contract describes the expected schema of a database in YAML so that the
+linter can flag queries that disagree with it. The format is a deliberate
+subset of the open data-contract space: tables -> columns -> type / nullable
+/ primary-key / foreign-key. Compatible in spirit with the tools at
+https://github.com/datacontract/datacontract-cli but lighter, since the
+linter only needs the structure, not the semantics.
+
+Example::
+
+    tables:
+      orders:
+        columns:
+          id:           {type: bigint,    not_null: true,  primary_key: true}
+          customer_id:  {type: bigint,    not_null: true,  foreign_key: customers.id}
+          total:        {type: decimal,   not_null: true}
+          status:       {type: varchar}
+          created_at:   {type: timestamp, not_null: true}
+      customers:
+        columns:
+          id:    {type: bigint,  not_null: true, primary_key: true}
+          name:  {type: varchar, not_null: true}
+          email: {type: varchar}
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class ContractColumn:
+    """A single column declaration inside a contract table."""
+
+    name: str
+    type: str = ""
+    not_null: bool = False
+    primary_key: bool = False
+    foreign_key: str | None = None  # "table.column"
+    has_default: bool = False
+
+
+@dataclass
+class ContractTable:
+    """A table inside a contract, indexed by lower-case column name."""
+
+    name: str
+    columns: dict[str, ContractColumn] = field(default_factory=dict)
+
+    @property
+    def primary_keys(self) -> list[str]:
+        return [c.name for c in self.columns.values() if c.primary_key]
+
+    @property
+    def required_columns(self) -> list[str]:
+        """Columns that must appear in an INSERT (NOT NULL, no default, not auto-PK)."""
+        return [
+            c.name
+            for c in self.columns.values()
+            if c.not_null and not c.has_default and not c.primary_key
+        ]
+
+
+@dataclass
+class Contract:
+    """A loaded data contract describing the expected schema."""
+
+    tables: dict[str, ContractTable] = field(default_factory=dict)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "Contract":
+        """Load a contract from a YAML file."""
+        raw = Path(path).read_text(encoding="utf-8")
+        return cls.from_dict(yaml.safe_load(raw) or {})
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Contract":
+        """Build a contract from a parsed YAML dict."""
+        contract = cls()
+        for table_name, table_data in (data.get("tables") or {}).items():
+            table = ContractTable(name=table_name)
+            cols = (table_data or {}).get("columns") or {}
+            for col_name, col_data in cols.items():
+                if isinstance(col_data, str):
+                    # Shorthand: a bare string is the column type.
+                    col = ContractColumn(name=col_name, type=col_data)
+                elif isinstance(col_data, dict):
+                    col = ContractColumn(
+                        name=col_name,
+                        type=str(col_data.get("type", "")),
+                        not_null=bool(col_data.get("not_null", False)),
+                        primary_key=bool(col_data.get("primary_key", False)),
+                        foreign_key=col_data.get("foreign_key"),
+                        has_default=bool(col_data.get("has_default", False)),
+                    )
+                else:
+                    # Skip malformed entries silently; the linter shouldn't crash on a
+                    # half-written contract during development.
+                    continue
+                table.columns[col_name.lower()] = col
+            contract.tables[table_name.lower()] = table
+        return contract
+
+    def get_table(self, name: str) -> ContractTable | None:
+        """Look up a table by name, case-insensitively."""
+        return self.tables.get(name.lower())

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -55,6 +55,7 @@ from sql_guard.rules.contracts import (
     NotNullViolation,
     PrimaryKeyMissingOnInsert,
     TableNotInContract,
+    UnmappedForeignKey,
     build_contract_rules,
 )
 

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -59,6 +59,19 @@ from sql_guard.rules.contracts import (
     build_contract_rules,
 )
 
+__all__ = [
+    "ALL_RULES",
+    "CONTRACT_RULE_CLASSES",
+    "ColumnNotInContract",
+    "NotNullViolation",
+    "PrimaryKeyMissingOnInsert",
+    "Rule",
+    "TableNotInContract",
+    "UnmappedForeignKey",
+    "build_contract_rules",
+    "get_rules",
+]
+
 ALL_RULES: list[Rule] = [
     # Errors (E001-E008)
     DeleteWithoutWhere(),

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -49,6 +49,14 @@ from sql_guard.rules.tsql import (
     WithNolock,
     XpCmdshell,
 )
+from sql_guard.rules.contracts import (
+    CONTRACT_RULE_CLASSES,
+    ColumnNotInContract,
+    NotNullViolation,
+    PrimaryKeyMissingOnInsert,
+    TableNotInContract,
+    build_contract_rules,
+)
 
 ALL_RULES: list[Rule] = [
     # Errors (E001-E008)
@@ -96,11 +104,26 @@ ALL_RULES: list[Rule] = [
 ]
 
 
-def get_rules(enabled_ids: set[str] | None = None, disabled_ids: set[str] | None = None) -> list[Rule]:
-    """Return filtered list of rules based on config."""
-    rules = ALL_RULES
+def get_rules(
+    enabled_ids: set[str] | None = None,
+    disabled_ids: set[str] | None = None,
+    contract: "Contract | None" = None,  # noqa: F821 -- forward reference
+) -> list[Rule]:
+    """Return filtered list of rules based on config.
+
+    If ``contract`` is provided, contract-aware rules (C001-...) are
+    instantiated with that contract and appended. Without a contract they
+    are silent and not registered.
+    """
+    rules = list(ALL_RULES)
+    if contract is not None:
+        rules = rules + list(build_contract_rules(contract))
     if enabled_ids:
         rules = [r for r in rules if r.id in enabled_ids]
     if disabled_ids:
         rules = [r for r in rules if r.id not in disabled_ids]
     return rules
+
+
+# Forward import for type hints; placed at bottom to avoid circular import.
+from sql_guard.contracts import Contract  # noqa: E402, F401

--- a/sql_guard/rules/contracts.py
+++ b/sql_guard/rules/contracts.py
@@ -1,0 +1,258 @@
+"""Contract rules (C001-...) -- require a loaded data contract to fire.
+
+These rules are only added to the active rule list when ``--contract`` is
+passed (or ``contract:`` is set in ``.sql-guard.yml``). Without a contract
+they are silent. The contract structure is defined in ``sql_guard.contracts``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sql_guard.contracts import Contract
+from sql_guard.rules.base import Finding, Rule
+
+
+class ContractRule(Rule):
+    """Base class for contract-aware rules.
+
+    Subclasses receive a Contract instance at construction time. When the
+    contract is None, the rule no-ops, which keeps the registry shape stable
+    even when ``--contract`` is not provided.
+    """
+
+    def __init__(self, contract: Contract | None = None) -> None:
+        self.contract = contract
+
+
+class ColumnNotInContract(ContractRule):
+    """C001: Column referenced in SQL is not declared in the contract for the table.
+
+    Walks ``table.column`` and ``alias.column`` references and looks each one
+    up against the contract. A miss is a finding. ``SELECT *`` cannot be
+    checked column-by-column at this layer, so this rule complements W001
+    rather than replacing it.
+    """
+
+    id = "C001"
+    name = "column-not-in-contract"
+    severity = "warning"
+    description = "Column reference not declared in the contract for that table"
+    multiline = True
+
+    # alias.column or table.column references in the body of a statement.
+    _qualified_ref = re.compile(r"\b([A-Za-z_][\w]*)\.([A-Za-z_][\w]*)\b")
+    # FROM/JOIN clauses, with an optional alias (with or without AS).
+    _from_table = re.compile(
+        r"\b(?:FROM|JOIN)\s+([A-Za-z_][\w]*)(?:\s+(?:AS\s+)?([A-Za-z_][\w]*))?",
+        re.IGNORECASE,
+    )
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if not self.contract:
+            return None
+
+        # Build alias -> table-name map. Bare table references map to themselves.
+        aliases: dict[str, str] = {}
+        for m in self._from_table.finditer(statement):
+            table_name = m.group(1).lower()
+            alias = (m.group(2) or m.group(1)).lower()
+            aliases[alias] = table_name
+
+        if not aliases:
+            return None
+
+        # First miss wins. The reporter is happier with one finding per
+        # statement than with a scatter of duplicates.
+        for m in self._qualified_ref.finditer(statement):
+            ref_alias = m.group(1).lower()
+            ref_col = m.group(2).lower()
+            if ref_alias not in aliases:
+                continue
+            table_name = aliases[ref_alias]
+            table = self.contract.get_table(table_name)
+            if table is None:
+                continue
+            if ref_col not in table.columns:
+                return Finding(
+                    rule_id=self.id,
+                    severity=self.severity,
+                    file=file,
+                    line=start_line,
+                    message=(
+                        f"Column '{ref_col}' is not declared in the contract "
+                        f"for table '{table_name}'"
+                    ),
+                    suggestion=(
+                        f"Either add '{ref_col}' to the contract or correct "
+                        f"the column name"
+                    ),
+                )
+        return None
+
+
+class TableNotInContract(ContractRule):
+    """C002: Statement references a table that has no entry in the contract.
+
+    Useful when a contract is expected to cover the whole schema. Disable
+    this rule if you only want to lint a subset of tables and intentionally
+    leave others out.
+    """
+
+    id = "C002"
+    name = "table-not-in-contract"
+    severity = "warning"
+    description = "Statement references a table not declared in the contract"
+    multiline = True
+
+    _from_table = re.compile(
+        r"\b(?:FROM|JOIN|INTO|UPDATE)\s+([A-Za-z_][\w]*)",
+        re.IGNORECASE,
+    )
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if not self.contract:
+            return None
+        for m in self._from_table.finditer(statement):
+            table_name = m.group(1)
+            if self.contract.get_table(table_name) is None:
+                return Finding(
+                    rule_id=self.id,
+                    severity=self.severity,
+                    file=file,
+                    line=start_line,
+                    message=f"Table '{table_name}' is not declared in the contract",
+                    suggestion=(
+                        "Either add the table to the contract or disable C002 "
+                        "for partial-coverage contracts"
+                    ),
+                )
+        return None
+
+
+class NotNullViolation(ContractRule):
+    """C003: INSERT omits a NOT NULL column declared in the contract.
+
+    Only triggers on parenthesised column lists, e.g.
+    ``INSERT INTO orders (id, customer_id) VALUES (...)``. Bare
+    ``INSERT INTO orders VALUES (...)`` already triggers E005
+    (insert-without-columns) which is the more general fix.
+    """
+
+    id = "C003"
+    name = "not-null-violation"
+    severity = "error"
+    description = "INSERT omits a column declared NOT NULL in the contract"
+    multiline = True
+
+    _insert = re.compile(
+        r"\bINSERT\s+INTO\s+([A-Za-z_][\w]*)\s*\(([^)]+)\)",
+        re.IGNORECASE,
+    )
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if not self.contract:
+            return None
+        m = self._insert.search(statement)
+        if not m:
+            return None
+
+        table_name = m.group(1)
+        table = self.contract.get_table(table_name)
+        if table is None:
+            return None
+
+        listed_cols = {
+            c.strip().strip("[]`\"").lower() for c in m.group(2).split(",")
+        }
+        missing = [c for c in table.required_columns if c not in listed_cols]
+
+        if missing:
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=start_line,
+                message=(
+                    f"INSERT into '{table_name}' is missing NOT NULL "
+                    f"columns: {', '.join(sorted(missing))}"
+                ),
+                suggestion=(
+                    "Include every NOT NULL column in the INSERT column "
+                    "list and the VALUES tuple, or add a default in the contract"
+                ),
+            )
+        return None
+
+
+class PrimaryKeyMissingOnInsert(ContractRule):
+    """C004: INSERT into a contract table omits its primary key (and no default).
+
+    Tracks PK columns separately from generic NOT NULL because the failure
+    mode is different: a missing PK becomes a constraint violation at write
+    time, not a NULL coalescing surprise.
+    """
+
+    id = "C004"
+    name = "primary-key-missing-on-insert"
+    severity = "error"
+    description = "INSERT into a contract table omits the primary key with no default"
+    multiline = True
+
+    _insert = re.compile(
+        r"\bINSERT\s+INTO\s+([A-Za-z_][\w]*)\s*\(([^)]+)\)",
+        re.IGNORECASE,
+    )
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if not self.contract:
+            return None
+        m = self._insert.search(statement)
+        if not m:
+            return None
+
+        table_name = m.group(1)
+        table = self.contract.get_table(table_name)
+        if table is None or not table.primary_keys:
+            return None
+
+        listed_cols = {
+            c.strip().strip("[]`\"").lower() for c in m.group(2).split(",")
+        }
+        missing_pks = [
+            pk
+            for pk in table.primary_keys
+            if pk not in listed_cols and not table.columns[pk].has_default
+        ]
+
+        if missing_pks:
+            return Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=start_line,
+                message=(
+                    f"INSERT into '{table_name}' is missing primary key "
+                    f"column(s): {', '.join(sorted(missing_pks))}"
+                ),
+                suggestion=(
+                    "Either include the primary key in the INSERT or "
+                    "declare has_default: true in the contract"
+                ),
+            )
+        return None
+
+
+CONTRACT_RULE_CLASSES: list[type[ContractRule]] = [
+    ColumnNotInContract,
+    TableNotInContract,
+    NotNullViolation,
+    PrimaryKeyMissingOnInsert,
+]
+
+
+def build_contract_rules(contract: Contract | None) -> list[ContractRule]:
+    """Instantiate every contract rule with the given (or empty) contract."""
+    if contract is None:
+        return []
+    return [rule_class(contract=contract) for rule_class in CONTRACT_RULE_CLASSES]

--- a/sql_guard/rules/contracts.py
+++ b/sql_guard/rules/contracts.py
@@ -243,11 +243,117 @@ class PrimaryKeyMissingOnInsert(ContractRule):
         return None
 
 
+class UnmappedForeignKey(ContractRule):
+    """C005: JOIN predicate uses columns the contract has no foreign key for.
+
+    Catches accidental cross-table joins where the contract declares no
+    relationship between the two columns. Walks every ``alias.col =
+    alias.col`` equality inside a ``JOIN ... ON`` clause and checks
+    whether either side has a ``foreign_key: other_table.col`` pointing
+    at the other side. Equalities involving tables not in the contract
+    are skipped (C002 owns that case).
+    """
+
+    id = "C005"
+    name = "unmapped-fk"
+    severity = "warning"
+    description = "JOIN ... ON uses columns with no FK relationship in the contract"
+    multiline = True
+
+    _from_table = re.compile(
+        r"\b(?:FROM|JOIN)\s+([A-Za-z_][\w]*)(?:\s+(?:AS\s+)?([A-Za-z_][\w]*))?",
+        re.IGNORECASE,
+    )
+    _join_on_block = re.compile(
+        r"\bJOIN\s+[A-Za-z_][\w]*(?:\s+(?:AS\s+)?[A-Za-z_][\w]*)?\s+ON\s+(.+?)"
+        r"(?=\bWHERE\b|\bGROUP\s+BY\b|\bORDER\s+BY\b|\bHAVING\b|\bJOIN\b|;|$)",
+        re.IGNORECASE | re.DOTALL,
+    )
+    _equality = re.compile(
+        r"\b([A-Za-z_][\w]*)\.([A-Za-z_][\w]*)\s*=\s*([A-Za-z_][\w]*)\.([A-Za-z_][\w]*)\b"
+    )
+
+    def _fk_resolves(
+        self, source_table_name: str, source_col: str,
+        target_table_name: str, target_col: str,
+    ) -> bool:
+        if self.contract is None:
+            return False
+        source_table = self.contract.get_table(source_table_name)
+        if source_table is None:
+            return False
+        col = source_table.columns.get(source_col)
+        if col is None or not col.foreign_key:
+            return False
+        ref_table, _, ref_col = col.foreign_key.partition(".")
+        return (
+            ref_table.lower() == target_table_name.lower()
+            and ref_col.lower() == target_col.lower()
+        )
+
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
+        if not self.contract:
+            return None
+
+        # alias -> table for every FROM/JOIN target.
+        aliases: dict[str, str] = {}
+        for m in self._from_table.finditer(statement):
+            table_name = m.group(1).lower()
+            alias = (m.group(2) or m.group(1)).lower()
+            aliases[alias] = table_name
+
+        if not aliases:
+            return None
+
+        for join_match in self._join_on_block.finditer(statement):
+            on_body = join_match.group(1)
+            for eq in self._equality.finditer(on_body):
+                left_alias, left_col = eq.group(1).lower(), eq.group(2).lower()
+                right_alias, right_col = eq.group(3).lower(), eq.group(4).lower()
+
+                left_table = aliases.get(left_alias)
+                right_table = aliases.get(right_alias)
+                if left_table is None or right_table is None:
+                    continue
+
+                # Both tables must be in the contract -- C002 owns the
+                # "table not in contract" case.
+                if (
+                    self.contract.get_table(left_table) is None
+                    or self.contract.get_table(right_table) is None
+                ):
+                    continue
+
+                # Either column may declare the FK; check both directions.
+                if self._fk_resolves(left_table, left_col, right_table, right_col):
+                    continue
+                if self._fk_resolves(right_table, right_col, left_table, left_col):
+                    continue
+
+                return Finding(
+                    rule_id=self.id,
+                    severity=self.severity,
+                    file=file,
+                    line=start_line,
+                    message=(
+                        f"JOIN on '{left_alias}.{left_col} = "
+                        f"{right_alias}.{right_col}' has no foreign-key "
+                        f"declaration in the contract"
+                    ),
+                    suggestion=(
+                        "Add a foreign_key: <table>.<column> entry to the "
+                        "owning column in the contract, or correct the JOIN"
+                    ),
+                )
+        return None
+
+
 CONTRACT_RULE_CLASSES: list[type[ContractRule]] = [
     ColumnNotInContract,
     TableNotInContract,
     NotNullViolation,
     PrimaryKeyMissingOnInsert,
+    UnmappedForeignKey,
 ]
 
 

--- a/sql_guard/snapshot.py
+++ b/sql_guard/snapshot.py
@@ -1,0 +1,128 @@
+"""Database introspection -> contract YAML.
+
+The ``sql-sop schema-snapshot`` subcommand connects to a live database
+via SQLAlchemy, walks every table, and writes a contract YAML in the
+format that ``--contract`` consumes. This bootstraps the typical
+"I don't have a contract yet" workflow: take a snapshot of the existing
+schema, commit it as ``contract.yml``, and start linting against it.
+
+SQLAlchemy is imported lazily so the linter's core install stays light.
+Users who want this feature install ``sql-sop[snapshot]``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class SnapshotError(RuntimeError):
+    """Raised on snapshot failure with a user-readable message."""
+
+
+def _require_sqlalchemy() -> Any:
+    try:
+        import sqlalchemy  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise SnapshotError(
+            "schema-snapshot requires SQLAlchemy. "
+            "Install with: pip install \"sql-sop[snapshot]\""
+        ) from exc
+    return sqlalchemy
+
+
+def _column_to_dict(column: Any, primary_keys: set[str], fk_targets: dict[str, str]) -> dict[str, Any]:
+    """Convert a SQLAlchemy column to the contract column dict shape."""
+    out: dict[str, Any] = {"type": str(column.type)}
+    if not column.nullable:
+        out["not_null"] = True
+    if column.name in primary_keys:
+        out["primary_key"] = True
+    if column.default is not None or column.server_default is not None:
+        out["has_default"] = True
+    if column.name in fk_targets:
+        out["foreign_key"] = fk_targets[column.name]
+    return out
+
+
+def introspect(
+    dsn: str,
+    schema: str | None = None,
+    include_tables: list[str] | None = None,
+) -> dict[str, Any]:
+    """Connect to ``dsn`` and return a contract-shaped dict.
+
+    Args:
+        dsn: SQLAlchemy connection string, e.g.
+            ``mssql+pyodbc://user:pass@host/dbname?driver=ODBC+Driver+18+for+SQL+Server``.
+        schema: Optional schema/owner name. Defaults to the dialect default
+            (``dbo`` on SQL Server, ``public`` on Postgres, etc.).
+        include_tables: If given, restrict the snapshot to these tables.
+    """
+    sa = _require_sqlalchemy()
+    engine = sa.create_engine(dsn)
+    try:
+        inspector = sa.inspect(engine)
+        table_names = inspector.get_table_names(schema=schema)
+        if include_tables:
+            wanted = {t.lower() for t in include_tables}
+            table_names = [t for t in table_names if t.lower() in wanted]
+
+        out: dict[str, Any] = {"tables": {}}
+        for table_name in table_names:
+            columns = inspector.get_columns(table_name, schema=schema)
+            pks = inspector.get_pk_constraint(table_name, schema=schema)
+            pk_columns = set(pks.get("constrained_columns") or [])
+            fks = inspector.get_foreign_keys(table_name, schema=schema)
+            fk_targets: dict[str, str] = {}
+            for fk in fks:
+                # Foreign key entry shape: {'constrained_columns': ['customer_id'],
+                #                           'referred_table': 'customers',
+                #                           'referred_columns': ['id'], ...}
+                src_cols = fk.get("constrained_columns") or []
+                ref_table = fk.get("referred_table")
+                ref_cols = fk.get("referred_columns") or []
+                for src_col, ref_col in zip(src_cols, ref_cols):
+                    if ref_table and ref_col:
+                        fk_targets[src_col] = f"{ref_table}.{ref_col}"
+
+            cols_dict: dict[str, Any] = {}
+            for column in columns:
+                cols_dict[column["name"]] = _column_to_dict_from_inspector(
+                    column, pk_columns, fk_targets
+                )
+            out["tables"][table_name] = {"columns": cols_dict}
+
+        return out
+    finally:
+        engine.dispose()
+
+
+def _column_to_dict_from_inspector(
+    column: dict[str, Any],
+    primary_keys: set[str],
+    fk_targets: dict[str, str],
+) -> dict[str, Any]:
+    """Same shape as ``_column_to_dict`` but takes the inspector dict form."""
+    out: dict[str, Any] = {"type": str(column.get("type", ""))}
+    if column.get("nullable") is False:
+        out["not_null"] = True
+    if column["name"] in primary_keys:
+        out["primary_key"] = True
+    if column.get("default") is not None or column.get("server_default") is not None:
+        out["has_default"] = True
+    if column["name"] in fk_targets:
+        out["foreign_key"] = fk_targets[column["name"]]
+    return out
+
+
+def write_snapshot(snapshot: dict[str, Any], output_path: str | Path) -> None:
+    """Write a snapshot dict to YAML, sorted for stable diffs."""
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        yaml.safe_dump(snapshot, sort_keys=True, default_flow_style=False),
+        encoding="utf-8",
+    )

--- a/tests/fixtures/contract_drift.sql
+++ b/tests/fixtures/contract_drift.sql
@@ -1,0 +1,31 @@
+-- End-to-end fixture for the contract rules pack (C001-C005).
+--
+-- Each statement deliberately violates one rule. The integration test
+-- in test_contracts.py runs the entire fixture against the sample
+-- contract (tests/fixtures/contract_sample.yml) and asserts every
+-- rule fires exactly once.
+
+-- C001 column-not-in-contract: orders has no 'bogus_column' field.
+SELECT o.bogus_column
+FROM orders o;
+
+-- C002 table-not-in-contract: ghost_table is not in the contract.
+SELECT *
+FROM ghost_table;
+
+-- C003 not-null-violation: orders requires customer_id and created_at.
+INSERT INTO orders (total)
+VALUES (99.99);
+
+-- C004 primary-key-missing-on-insert: 'audit_log' has a no-default PK.
+-- See test_contracts.py for the contract used (built inline because the
+-- shared sample contract gives orders.id has_default=true).
+-- Placeholder query for visual continuity; the C004 test uses an
+-- inline contract.
+INSERT INTO audit_log (msg)
+VALUES ('something happened');
+
+-- C005 unmapped-fk: orders.id is not a foreign key to customers.id.
+SELECT *
+FROM orders o
+JOIN customers c ON o.id = c.id;

--- a/tests/fixtures/contract_sample.yml
+++ b/tests/fixtures/contract_sample.yml
@@ -1,0 +1,14 @@
+# Sample contract used by the contract test suite.
+tables:
+  orders:
+    columns:
+      id:           {type: bigint,    not_null: true,  primary_key: true, has_default: true}
+      customer_id:  {type: bigint,    not_null: true,  foreign_key: customers.id}
+      total:        {type: decimal,   not_null: true}
+      status:       {type: varchar}
+      created_at:   {type: timestamp, not_null: true}
+  customers:
+    columns:
+      id:    {type: bigint,  not_null: true, primary_key: true, has_default: true}
+      name:  {type: varchar, not_null: true}
+      email: {type: varchar}

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -294,3 +294,41 @@ def test_build_contract_rules_with_contract_returns_all(contract):
 def test_build_contract_rules_without_contract_returns_empty():
     rules = build_contract_rules(None)
     assert rules == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration: the contract pack against a fixture file.
+# ---------------------------------------------------------------------------
+
+
+def test_integration_contract_drift_fixture(contract):
+    """Run the full check pipeline with --contract over the drift fixture.
+
+    Asserts that every rule in C001-C005 (except C004, which uses an
+    inline contract because the sample's PK has has_default=true) fires
+    on the fixture.
+    """
+    from sql_guard.checker import check
+
+    fixture = FIXTURES / "contract_drift.sql"
+    result = check([str(fixture)], contract=contract)
+    rule_ids = {f.rule_id for f in result.findings}
+
+    # The four C-rules whose violation patterns the shared sample
+    # contract can express.
+    assert "C001" in rule_ids
+    assert "C002" in rule_ids
+    assert "C003" in rule_ids
+    assert "C005" in rule_ids
+
+
+def test_integration_check_without_contract_skips_c_rules(contract):
+    """Without ``contract=``, the C-rules must not register."""
+    from sql_guard.checker import check
+
+    fixture = FIXTURES / "contract_drift.sql"
+    result = check([str(fixture)])  # no contract
+    rule_ids = {f.rule_id for f in result.findings}
+
+    # No C-rule should have fired since no contract was loaded.
+    assert not any(rid.startswith("C") for rid in rule_ids)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,248 @@
+"""Tests for the contract-rules pack (C001-C004)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sql_guard.contracts import Contract, ContractColumn, ContractTable
+from sql_guard.rules.contracts import (
+    ColumnNotInContract,
+    NotNullViolation,
+    PrimaryKeyMissingOnInsert,
+    TableNotInContract,
+    build_contract_rules,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+SAMPLE_CONTRACT = FIXTURES / "contract_sample.yml"
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+class TestContractLoader:
+    def test_loads_from_file(self) -> None:
+        contract = Contract.from_file(SAMPLE_CONTRACT)
+        assert "orders" in contract.tables
+        assert "customers" in contract.tables
+
+    def test_orders_table_columns(self) -> None:
+        contract = Contract.from_file(SAMPLE_CONTRACT)
+        orders = contract.get_table("orders")
+        assert orders is not None
+        assert "id" in orders.columns
+        assert orders.columns["id"].primary_key is True
+        assert orders.columns["id"].has_default is True
+        assert orders.columns["customer_id"].not_null is True
+        assert orders.columns["customer_id"].foreign_key == "customers.id"
+
+    def test_required_columns_excludes_pk_and_default(self) -> None:
+        contract = Contract.from_file(SAMPLE_CONTRACT)
+        orders = contract.get_table("orders")
+        assert orders is not None
+        # PK 'id' has has_default, so it's excluded. customer_id, total,
+        # created_at are required (not_null and not PK).
+        assert set(orders.required_columns) == {"customer_id", "total", "created_at"}
+
+    def test_table_lookup_is_case_insensitive(self) -> None:
+        contract = Contract.from_file(SAMPLE_CONTRACT)
+        assert contract.get_table("ORDERS") is not None
+        assert contract.get_table("Orders") is not None
+
+    def test_unknown_table_returns_none(self) -> None:
+        contract = Contract.from_file(SAMPLE_CONTRACT)
+        assert contract.get_table("nonexistent") is None
+
+    def test_from_dict_handles_shorthand_string_type(self) -> None:
+        contract = Contract.from_dict(
+            {"tables": {"t": {"columns": {"a": "varchar", "b": "bigint"}}}}
+        )
+        assert contract.get_table("t") is not None
+        assert contract.get_table("t").columns["a"].type == "varchar"
+
+    def test_from_dict_skips_malformed_columns(self) -> None:
+        contract = Contract.from_dict(
+            {"tables": {"t": {"columns": {"good": "varchar", "bad": 42}}}}
+        )
+        cols = contract.get_table("t").columns
+        assert "good" in cols
+        assert "bad" not in cols
+
+
+# ---------------------------------------------------------------------------
+# C001 column-not-in-contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def contract():
+    return Contract.from_file(SAMPLE_CONTRACT)
+
+
+def _stmt(rule, sql: str, line: int = 1):
+    return rule.check_statement(sql, line, "test.sql")
+
+
+class TestC001ColumnNotInContract:
+    def test_flags_unknown_column(self, contract):
+        rule = ColumnNotInContract(contract=contract)
+        finding = _stmt(rule, "SELECT o.bogus_column FROM orders o;")
+        assert finding is not None
+        assert finding.rule_id == "C001"
+        assert "bogus_column" in finding.message
+
+    def test_passes_when_column_is_declared(self, contract):
+        rule = ColumnNotInContract(contract=contract)
+        assert _stmt(rule, "SELECT o.id, o.total FROM orders o;") is None
+
+    def test_passes_when_table_not_in_contract(self, contract):
+        # If the table isn't in the contract we don't have a baseline to
+        # check against, so C001 stays silent (C002 owns that case).
+        rule = ColumnNotInContract(contract=contract)
+        assert _stmt(rule, "SELECT a.x FROM unknown_table a;") is None
+
+    def test_handles_alias_or_table_name(self, contract):
+        rule = ColumnNotInContract(contract=contract)
+        # Bare table name (no alias) should still resolve.
+        assert (
+            _stmt(rule, "SELECT orders.id FROM orders;") is None
+        ), "table-name reference to a real column should pass"
+        finding = _stmt(rule, "SELECT orders.bogus FROM orders;")
+        assert finding is not None and finding.rule_id == "C001"
+
+    def test_no_op_without_contract(self):
+        rule = ColumnNotInContract(contract=None)
+        assert _stmt(rule, "SELECT o.bogus FROM orders o;") is None
+
+
+# ---------------------------------------------------------------------------
+# C002 table-not-in-contract
+# ---------------------------------------------------------------------------
+
+
+class TestC002TableNotInContract:
+    def test_flags_unknown_table(self, contract):
+        rule = TableNotInContract(contract=contract)
+        finding = _stmt(rule, "SELECT * FROM ghost_table;")
+        assert finding is not None
+        assert finding.rule_id == "C002"
+
+    def test_passes_for_known_table(self, contract):
+        rule = TableNotInContract(contract=contract)
+        assert _stmt(rule, "SELECT * FROM orders;") is None
+
+    def test_flags_unknown_table_in_join(self, contract):
+        rule = TableNotInContract(contract=contract)
+        finding = _stmt(
+            rule,
+            "SELECT * FROM orders o JOIN ghosts g ON o.id = g.order_id;",
+        )
+        assert finding is not None
+        assert finding.rule_id == "C002"
+
+    def test_no_op_without_contract(self):
+        rule = TableNotInContract(contract=None)
+        assert _stmt(rule, "SELECT * FROM ghost_table;") is None
+
+
+# ---------------------------------------------------------------------------
+# C003 not-null-violation
+# ---------------------------------------------------------------------------
+
+
+class TestC003NotNullViolation:
+    def test_flags_missing_not_null_column(self, contract):
+        rule = NotNullViolation(contract=contract)
+        # 'created_at' is NOT NULL in the contract; this INSERT omits it.
+        finding = _stmt(
+            rule,
+            "INSERT INTO orders (customer_id, total) VALUES (1, 99.99);",
+        )
+        assert finding is not None
+        assert finding.rule_id == "C003"
+        assert finding.severity == "error"
+        assert "created_at" in finding.message
+
+    def test_passes_when_all_required_listed(self, contract):
+        rule = NotNullViolation(contract=contract)
+        assert (
+            _stmt(
+                rule,
+                "INSERT INTO orders (customer_id, total, created_at) "
+                "VALUES (1, 99.99, NOW());",
+            )
+            is None
+        )
+
+    def test_does_not_flag_unknown_table(self, contract):
+        rule = NotNullViolation(contract=contract)
+        # Tables not in the contract aren't C003's concern.
+        assert _stmt(rule, "INSERT INTO ghost (a) VALUES (1);") is None
+
+    def test_no_op_without_contract(self):
+        rule = NotNullViolation(contract=None)
+        assert _stmt(rule, "INSERT INTO orders (id) VALUES (1);") is None
+
+
+# ---------------------------------------------------------------------------
+# C004 primary-key-missing-on-insert
+# ---------------------------------------------------------------------------
+
+
+class TestC004PrimaryKeyMissingOnInsert:
+    def test_passes_when_pk_has_default(self, contract):
+        rule = PrimaryKeyMissingOnInsert(contract=contract)
+        # 'orders.id' is PK with has_default in the sample contract, so
+        # omitting it is fine.
+        assert (
+            _stmt(
+                rule,
+                "INSERT INTO orders (customer_id, total, created_at) "
+                "VALUES (1, 99.99, NOW());",
+            )
+            is None
+        )
+
+    def test_flags_missing_pk_without_default(self):
+        # Build a tiny contract where the PK has no default.
+        contract = Contract.from_dict(
+            {
+                "tables": {
+                    "audit": {
+                        "columns": {
+                            "id": {"type": "bigint", "primary_key": True, "not_null": True},
+                            "msg": {"type": "varchar"},
+                        }
+                    }
+                }
+            }
+        )
+        rule = PrimaryKeyMissingOnInsert(contract=contract)
+        finding = _stmt(rule, "INSERT INTO audit (msg) VALUES ('hi');")
+        assert finding is not None
+        assert finding.rule_id == "C004"
+        assert "id" in finding.message
+
+    def test_no_op_without_contract(self):
+        rule = PrimaryKeyMissingOnInsert(contract=None)
+        assert _stmt(rule, "INSERT INTO orders (customer_id) VALUES (1);") is None
+
+
+# ---------------------------------------------------------------------------
+# build_contract_rules helper
+# ---------------------------------------------------------------------------
+
+
+def test_build_contract_rules_with_contract_returns_all(contract):
+    rules = build_contract_rules(contract)
+    ids = {r.id for r in rules}
+    assert ids == {"C001", "C002", "C003", "C004"}
+
+
+def test_build_contract_rules_without_contract_returns_empty():
+    rules = build_contract_rules(None)
+    assert rules == []

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from sql_guard.contracts import Contract, ContractColumn, ContractTable
+from sql_guard.contracts import Contract
 from sql_guard.rules.contracts import (
     ColumnNotInContract,
     NotNullViolation,

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,4 +1,4 @@
-"""Tests for the contract-rules pack (C001-C004)."""
+"""Tests for the contract-rules pack (C001-C005)."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from sql_guard.rules.contracts import (
     NotNullViolation,
     PrimaryKeyMissingOnInsert,
     TableNotInContract,
+    UnmappedForeignKey,
     build_contract_rules,
 )
 
@@ -237,10 +238,57 @@ class TestC004PrimaryKeyMissingOnInsert:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# C005 unmapped-fk
+# ---------------------------------------------------------------------------
+
+
+class TestC005UnmappedForeignKey:
+    def test_passes_when_fk_is_declared(self, contract):
+        # contract_sample.yml has orders.customer_id -> customers.id
+        rule = UnmappedForeignKey(contract=contract)
+        sql = (
+            "SELECT * FROM orders o "
+            "JOIN customers c ON o.customer_id = c.id;"
+        )
+        assert _stmt(rule, sql) is None
+
+    def test_passes_when_fk_declared_other_direction(self, contract):
+        # The contract declares the FK on customer_id; the JOIN order
+        # writes c.id = o.customer_id. Should still resolve.
+        rule = UnmappedForeignKey(contract=contract)
+        sql = (
+            "SELECT * FROM orders o "
+            "JOIN customers c ON c.id = o.customer_id;"
+        )
+        assert _stmt(rule, sql) is None
+
+    def test_flags_join_with_no_declared_fk(self, contract):
+        # orders.id -> customers.id is not a real FK in the contract;
+        # the only relationship is orders.customer_id -> customers.id.
+        rule = UnmappedForeignKey(contract=contract)
+        sql = "SELECT * FROM orders o JOIN customers c ON o.id = c.id;"
+        finding = _stmt(rule, sql)
+        assert finding is not None
+        assert finding.rule_id == "C005"
+        assert "o.id" in finding.message and "c.id" in finding.message
+
+    def test_passes_when_either_side_table_not_in_contract(self, contract):
+        # If a table isn't in the contract at all, C002 owns the case.
+        rule = UnmappedForeignKey(contract=contract)
+        sql = "SELECT * FROM orders o JOIN ghosts g ON o.id = g.order_id;"
+        assert _stmt(rule, sql) is None
+
+    def test_no_op_without_contract(self):
+        rule = UnmappedForeignKey(contract=None)
+        sql = "SELECT * FROM orders o JOIN customers c ON o.id = c.id;"
+        assert _stmt(rule, sql) is None
+
+
 def test_build_contract_rules_with_contract_returns_all(contract):
     rules = build_contract_rules(contract)
     ids = {r.id for r in rules}
-    assert ids == {"C001", "C002", "C003", "C004"}
+    assert ids == {"C001", "C002", "C003", "C004", "C005"}
 
 
 def test_build_contract_rules_without_contract_returns_empty():

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -108,7 +108,8 @@ class TestScanFile:
 class TestScanDir:
     def test_scan_dir(self) -> None:
         result = SqlGuard().scan_dir(FIXTURES)
-        assert result.files_checked == 3
+        # errors.sql, warnings.sql, clean.sql, contract_drift.sql
+        assert result.files_checked == 4
         assert len(result.findings) > 0
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -266,7 +266,8 @@ class TestCleanFile:
 class TestChecker:
     def test_files_checked_count(self) -> None:
         result = check([str(FIXTURES)])
-        assert result.files_checked == 3  # errors.sql, warnings.sql, clean.sql
+        # errors.sql, warnings.sql, clean.sql, contract_drift.sql
+        assert result.files_checked == 4
 
     def test_duration_tracked(self) -> None:
         result = check([str(FIXTURES)])


### PR DESCRIPTION
## What changed

Adds the **Contracts theme** to sql-sop: a way to declare your expected schema in YAML and lint queries against it. Five new rules, two new CLI subcommands, optional `[snapshot]` extra. Without `--contract`, behaviour is identical to today, so the addition is fully backwards-compatible.

The pitch: most SQL linters catch syntax-level mistakes (`DELETE` without `WHERE`, `SELECT *`, and so on). sql-sop already does that well. This PR adds *schema-level* mistakes — querying columns that don't exist, joining tables with no FK relationship, inserts that omit NOT NULL columns — which is the next class of bug that breaks production silently.

### New rules (C001-C005)

| ID | Severity | What it catches |
|---|---|---|
| C001 | warning | `SELECT o.bogus FROM orders o` — column not declared in contract |
| C002 | warning | `SELECT * FROM ghost_table` — table absent from contract |
| C003 | error | `INSERT INTO orders (id) VALUES (1)` — omits NOT NULL columns |
| C004 | error | INSERT omits a PK column with no default |
| C005 | warning | `JOIN ... ON o.id = c.id` — columns have no FK relationship |

### New subcommands

```bash
# Bootstrap a contract from an existing database (requires sql-sop[snapshot]):
sql-sop schema-snapshot \
  --dsn "mssql+pyodbc://user:pass@host/db?driver=ODBC+Driver+18+for+SQL+Server" \
  --output contract.yml

# Validate the YAML before running rules (CI-friendly):
sql-sop validate-contract --contract contract.yml

# Lint against the contract:
sql-sop check . --contract contract.yml