### PR TITLE
chore: release v0.7.0 contracts pack, schema-snapshot, validate-contract

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   # Runs sql-sop on the project's own fixtures + any staged .sql files
   # so a regression in a rule is caught before it ships.
   - repo: https://github.com/Pawansingh3889/sql-guard
-    rev: v0.6.2
+    rev: v0.7.0
     hooks:
       - id: sql-sop
         args: [--severity, error]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
+_Nothing yet. Next release will track post-v0.7.0 work._
+
 ## [0.7.0] - 2026-05-02
 
 Headline release: schema-aware linting via the new **Contracts pack**, three community-contributed rules (W014 / W015 / W022), and the `schema-snapshot` and `validate-contract` subcommands. Core registry is 43 rules (10 errors, 28 warnings, 5 Python-source). With `--contract` enabled the registry grows to 48 rules (12 errors, 31 warnings, 5 Python-source). Without `--contract` behaviour is identical to v0.6.x and there are no breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-02
+
+Headline release: schema-aware linting via the new **Contracts pack**, three community-contributed rules (W014 / W015 / W022), and the `schema-snapshot` and `validate-contract` subcommands. Core registry is 43 rules (10 errors, 28 warnings, 5 Python-source). With `--contract` enabled the registry grows to 48 rules (12 errors, 31 warnings, 5 Python-source). Without `--contract` behaviour is identical to v0.6.x and there are no breaking changes.
+
 ### Added
 
 - **W014 `case-without-else`** - warns when a `CASE ... END` block has

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ One bad SQL query can delete production data, expose customer records, or bring 
 
 | | |
 |---|---|
-| Rules | 43 (10 errors, 28 warnings, 5 Python-source) |
-| Tests | 152 |
+| Rules | 43 (10 errors, 28 warnings, 5 Python-source); 48 with `--contract` |
+| Tests | 210 |
 | Coverage | 86% |
 | Scan speed | 0.08s across 200 files |
 | PyPI downloads | 500+/month |
-| Version | 0.6.2 |
+| Version | 0.7.0 |
 
 ### Fluent API (v0.2.0)
 
@@ -43,7 +43,7 @@ print(result.summary()) # "1 error, 0 warnings in 1 statement"
 
 ---
 
-Fast, rule-based SQL linter. 43 rules (38 SQL + 5 Python), including SQL Server-focused rules for T-SQL shops. Inline disable, project config, git-changed-only mode, and SARIF output for GitHub Code Scanning. 500+ monthly downloads on PyPI.
+Fast, rule-based SQL linter. 43 rules (38 SQL + 5 Python), with an optional Contracts pack (5 schema-aware rules) when you supply `--contract path.yml`. SQL Server-focused rules for T-SQL shops. Inline disable, project config, git-changed-only mode, and SARIF output for GitHub Code Scanning. 500+ monthly downloads on PyPI.
 
 Catches dangerous SQL before it reaches production -- DELETE without WHERE, UPDATE without WHERE, SQL injection patterns, SELECT *, and 20 more. Runs as a **CLI tool**, **pre-commit hook**, and **GitHub Action**.
 
@@ -132,7 +132,7 @@ You want both.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/Pawansingh3889/sql-guard
-    rev: v0.6.2
+    rev: v0.7.0
     hooks:
       - id: sql-guard
         args: [--severity, error]  # only block on errors locally

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,13 +2,18 @@
 
 This is the maintainer's working roadmap. It tells you what's likely to land in upcoming releases, what's deliberately out of scope, and where contributions are most welcome. It's a living document — open an issue to discuss anything that surprises you.
 
-Last updated: 2026-04-27.
+Last updated: 2026-05-02.
 
 ## Current release
 
-**v0.6.x** is in maintenance. Headline features as of v0.6.1 on PyPI: 38 rules (33 SQL + 5 Python), T-SQL safety pack (T001-T005), migration guards, inline `-- sql-guard: disable=...` directives, `.sql-guard.yml` config, `--changed-only` flag, SARIF 2.1.0 output for GitHub Code Scanning, libCST scanner for Python source.
+**v0.7.0** is the current PyPI release. Headline additions over v0.6.x:
 
-`main` is at 39 rules after [W013 window-without-partition](https://github.com/Pawansingh3889/sql-guard/pull/21) merged 2026-04-26. **v0.6.2 patch release pending** to ship W013 to PyPI users.
+- **Contracts pack (C001-C005)** — schema-aware linting against a YAML data contract. Opt-in via `--contract path.yml`; silent without it.
+- **`schema-snapshot` subcommand** — bootstrap a contract from a live database via SQLAlchemy introspection. Requires the `[snapshot]` extra.
+- **`validate-contract` subcommand** — validate the contract YAML before running rules, CI-friendly.
+- Three community-contributed rules: **W014 `case-without-else`** (@hellozzm), **W015 `join-function-on-column`** (@mvanhorn), **W022 `cross-join-explicit`** (@vibeyclaw).
+
+Total: 43 rules in the core registry (10 errors, 28 warnings, 5 Python-source), growing to 48 (12 errors, 31 warnings, 5 Python-source) when `--contract` is supplied.
 
 ## v0.7 — Performance Rules Pack
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sql-sop"
-version = "0.6.2"
+version = "0.7.0"
 description = "Fast rule-based SQL linter. Pre-commit hook + GitHub Action + CLI."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## What changed

Cuts **v0.7.0** to PyPI. This is the headline release for the Contracts theme: schema-aware linting via the new C001-C005 rule pack, two new CLI subcommands (`schema-snapshot`, `validate-contract`), and three community-contributed rules (W014 / W015 / W022).

### Headline features

| Area | Change |
|---|---|
| **Contracts pack** | New `--contract path.yml` flag enables 5 schema-aware rules (C001-C005). Without it, behaviour is identical to v0.6.x |
| **`schema-snapshot`** | Bootstrap a contract from a live database via SQLAlchemy introspection. Requires `pip install "sql-sop[snapshot]"` |
| **`validate-contract`** | Validate the YAML before running rules. CI-friendly, exits non-zero on parse failure |
| **W014 `case-without-else`** | Walks `CASE`/`END` token-by-token. Contributed by @hellozzm (#32) |
| **W015 `join-function-on-column`** | JOIN-side companion to W003. Contributed by @mvanhorn (#33) |
| **W022 `cross-join-explicit`** | Flags explicit `CROSS JOIN`. Contributed by @vibeyclaw (#31) |

### Rule counts

- **Core registry**: 43 rules (10 errors, 28 warnings, 5 Python-source)
- **With `--contract`**: 48 rules (12 errors, 31 warnings, 5 Python-source)

### Backwards compatibility

No breaking changes. All Contracts-pack rules require an explicit `--contract` flag (or `contract:` field in `.sql-guard.yml`); silent without it.

## Files in this PR

- `pyproject.toml`: 0.6.2 → 0.7.0
- `CHANGELOG.md`: cut [Unreleased] → [0.7.0] - 2026-05-02 with headline summary
- `README.md`: bumped Version, Tests count (152 → 210), pre-commit rev pin (v0.6.2 → v0.7.0), description text
- `.pre-commit-config.yaml`: self-reference rev pin (v0.6.2 → v0.7.0)
- `ROADMAP.md`: refreshed Current release section to point at v0.7.0

## Tests

- `pytest`: 209 passed, 1 skipped
- `ruff check`: clean

## Next steps after merge

1. Tag `v0.7.0` on main
2. Push tag to trigger the release workflow (Trusted Publishing to PyPI)
3. Verify on https://pypi.org/project/sql-sop/0.7.0/
4. Create GitHub Release with the CHANGELOG body
5. Update any downstream consumers (sql-sop-mcp, dependent projects) to require `>=0.7.0` if they want the contract loader API