### PR TITLE
Fix S001 implicit-cross-join false negatives (aliases, schema-qual, multi-line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,7 @@ Headline release: schema-aware linting via the new **Contracts pack**, three com
 - `test_duration_tracked` no longer fails on fast hardware where
   `time.perf_counter` resolution is coarser than the scan duration.
   Assertion relaxed from `> 0` to `>= 0` with an explicit float type check.
-- Added W014: warn on OVER() without ORDER BY / PARTITION BY to flag non-deterministic window 
+- Added W014: warn on OVER() without ORDER BY / PARTITION BY to flag non-deterministic window
   functions.
 
 ## [0.4.1] - 2026-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
   ([#39](https://github.com/Pawansingh3889/sql-guard/pull/39)).
   Resolves #3.
 
+### Fixed
+
+- **S001 `implicit-cross-join`** - the previous regex only matched a
+  comma immediately after the first word after `FROM`. Most real-world
+  comma-joins slipped through silently: aliased tables
+  (`FROM orders o, customers c`), schema-qualified names
+  (`FROM raw.orders, raw.customers`), three-or-more-way joins, and
+  multi-line layouts. Replaced with a paren-depth-aware scan that
+  walks from each `FROM` keyword to the next `WHERE` / `GROUP BY` /
+  `ORDER BY` / `HAVING` / `LIMIT` / explicit `JOIN` / `UNION` /
+  `EXCEPT` / `INTERSECT`, flagging the first depth-0 comma. Strings
+  and comments are stripped first. `DELETE FROM` is skipped.
+  `, LATERAL ...` is recognised as a legitimate
+  Snowflake/Postgres lateral join and not flagged. Resolves #41
+  (the W027 comma-join request was a duplicate of S001).
+
 ## [0.7.0] - 2026-05-02
 
 Headline release: schema-aware linting via the new **Contracts pack**, three community-contributed rules (W014 / W015 / W022), and the `schema-snapshot` and `validate-contract` subcommands. Core registry is 43 rules (10 errors, 28 warnings, 5 Python-source). With `--contract` enabled the registry grows to 48 rules (12 errors, 31 warnings, 5 Python-source). Without `--contract` behaviour is identical to v0.6.x and there are no breaking changes.

--- a/scripts/scaffold_rule.py
+++ b/scripts/scaffold_rule.py
@@ -76,7 +76,7 @@ class {klass}(Rule):
 '''
 
 
-TEST_TEMPLATE = '''\
+TEST_TEMPLATE = """\
 def test_{code_lower}_fires_on_bad_sql():
     rule = {klass}()
     finding = _line(rule, {bad!r})
@@ -87,7 +87,7 @@ def test_{code_lower}_fires_on_bad_sql():
 def test_{code_lower}_passes_on_safe_sql():
     rule = {klass}()
     assert _line(rule, {good!r}) is None
-'''
+"""
 
 
 def main() -> int:
@@ -96,8 +96,12 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__.split("Example:")[1] if "Example:" in __doc__ else "",
     )
-    parser.add_argument("--code", required=True, help="Rule code, e.g. W024 (must match [EWTSP]NNN)")
-    parser.add_argument("--name", required=True, help="Rule name in kebab-case, e.g. negate-of-equality")
+    parser.add_argument(
+        "--code", required=True, help="Rule code, e.g. W024 (must match [EWTSP]NNN)"
+    )
+    parser.add_argument(
+        "--name", required=True, help="Rule name in kebab-case, e.g. negate-of-equality"
+    )
     parser.add_argument("--description", required=True, help="One-line description for the rule")
     parser.add_argument("--regex", default="YOUR_PATTERN_HERE", help="Regex pattern to match")
     parser.add_argument("--message", help="Finding message (defaults to description)")
@@ -106,8 +110,12 @@ def main() -> int:
         default="Refactor for clarity and performance",
         help="Suggested fix shown alongside the finding",
     )
-    parser.add_argument("--bad", default="-- TODO: bad SQL example", help="SQL example that should fire")
-    parser.add_argument("--good", default="-- TODO: safe SQL example", help="SQL example that should not fire")
+    parser.add_argument(
+        "--bad", default="-- TODO: bad SQL example", help="SQL example that should fire"
+    )
+    parser.add_argument(
+        "--good", default="-- TODO: safe SQL example", help="SQL example that should not fire"
+    )
     args = parser.parse_args()
 
     code = args.code.upper()

--- a/sql_guard/checker.py
+++ b/sql_guard/checker.py
@@ -127,29 +127,35 @@ def check_file(
         try:
             content = path.read_text(encoding="latin-1")
         except Exception as e:
-            return [Finding(
+            return [
+                Finding(
+                    rule_id="SYS",
+                    severity="error",
+                    file=file_str,
+                    line=0,
+                    message=f"Cannot read file: {e}",
+                )
+            ]
+    except PermissionError:
+        return [
+            Finding(
+                rule_id="SYS",
+                severity="error",
+                file=file_str,
+                line=0,
+                message="Permission denied",
+            )
+        ]
+    except OSError as e:
+        return [
+            Finding(
                 rule_id="SYS",
                 severity="error",
                 file=file_str,
                 line=0,
                 message=f"Cannot read file: {e}",
-            )]
-    except PermissionError:
-        return [Finding(
-            rule_id="SYS",
-            severity="error",
-            file=file_str,
-            line=0,
-            message="Permission denied",
-        )]
-    except OSError as e:
-        return [Finding(
-            rule_id="SYS",
-            severity="error",
-            file=file_str,
-            line=0,
-            message=f"Cannot read file: {e}",
-        )]
+            )
+        ]
 
     single_pass_rules = [r for r in rules if not r.multiline]
     multi_line_rules = [r for r in rules if r.multiline]

--- a/sql_guard/cli.py
+++ b/sql_guard/cli.py
@@ -30,9 +30,13 @@ console = Console()
 @app.command("check")
 def check_cmd(
     paths: list[str] = typer.Argument(default=None, help="Files or directories to check."),
-    severity: str = typer.Option("warning", "--severity", "-s", help="Minimum severity: error or warning."),
+    severity: str = typer.Option(
+        "warning", "--severity", "-s", help="Minimum severity: error or warning."
+    ),
     fail_fast: bool = typer.Option(False, "--fail-fast", help="Stop after first error."),
-    disable: Optional[list[str]] = typer.Option(None, "--disable", "-d", help="Rule IDs to disable."),
+    disable: Optional[list[str]] = typer.Option(
+        None, "--disable", "-d", help="Rule IDs to disable."
+    ),
     include_python: bool = typer.Option(
         False,
         "--include-python",
@@ -96,14 +100,10 @@ def check_cmd(
         try:
             contract = Contract.from_file(effective_contract_path)
         except FileNotFoundError:
-            console.print(
-                f"[red]Contract file not found:[/red] {effective_contract_path}"
-            )
+            console.print(f"[red]Contract file not found:[/red] {effective_contract_path}")
             raise typer.Exit(code=2)
         except Exception as exc:
-            console.print(
-                f"[red]Failed to load contract {effective_contract_path}:[/red] {exc}"
-            )
+            console.print(f"[red]Failed to load contract {effective_contract_path}:[/red] {exc}")
             raise typer.Exit(code=2)
 
     if changed_only:
@@ -200,12 +200,7 @@ def validate_contract_cmd(
 
     column_count = sum(len(t.columns) for t in contract.tables.values())
     pk_count = sum(len(t.primary_keys) for t in contract.tables.values())
-    fk_count = sum(
-        1
-        for t in contract.tables.values()
-        for c in t.columns.values()
-        if c.foreign_key
-    )
+    fk_count = sum(1 for t in contract.tables.values() for c in t.columns.values() if c.foreign_key)
 
     console.print(
         f"[green]OK[/green] {contract_path}: {table_count} tables, "
@@ -251,9 +246,7 @@ def schema_snapshot_cmd(
     from sql_guard import snapshot as snapshot_mod
 
     try:
-        data = snapshot_mod.introspect(
-            dsn=dsn, schema=schema, include_tables=include_table
-        )
+        data = snapshot_mod.introspect(dsn=dsn, schema=schema, include_tables=include_table)
     except snapshot_mod.SnapshotError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=2)
@@ -264,9 +257,7 @@ def schema_snapshot_cmd(
     snapshot_mod.write_snapshot(data, output_path)
 
     table_count = len(data.get("tables") or {})
-    console.print(
-        f"[green]OK[/green] wrote {output_path} with {table_count} tables."
-    )
+    console.print(f"[green]OK[/green] wrote {output_path} with {table_count} tables.")
 
 
 @app.command()

--- a/sql_guard/fluent.py
+++ b/sql_guard/fluent.py
@@ -67,10 +67,7 @@ class ScanResult:
         if not parts:
             return f"no issues in {self.files_checked} file{'s' if self.files_checked != 1 else ''}"
         count_str = ", ".join(parts)
-        return (
-            f"{count_str} in "
-            f"{self.files_checked} file{'s' if self.files_checked != 1 else ''}"
-        )
+        return f"{count_str} in {self.files_checked} file{'s' if self.files_checked != 1 else ''}"
 
     def __len__(self) -> int:
         return len(self.findings)
@@ -123,7 +120,10 @@ class SqlGuard:
         rules = get_rules(enabled_ids=self._enabled, disabled_ids=self._disabled)
 
         with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".sql", delete=False, encoding="utf-8",
+            mode="w",
+            suffix=".sql",
+            delete=False,
+            encoding="utf-8",
         ) as tmp:
             tmp.write(sql_string)
             tmp_path = Path(tmp.name)

--- a/sql_guard/git_filter.py
+++ b/sql_guard/git_filter.py
@@ -54,9 +54,7 @@ def changed_files(base: str | None = None) -> set[Path] | None:
     return out
 
 
-def filter_to_changed(
-    discovered: list[Path], base: str | None = None
-) -> tuple[list[Path], bool]:
+def filter_to_changed(discovered: list[Path], base: str | None = None) -> tuple[list[Path], bool]:
     """Filter ``discovered`` to only the files git reports as changed.
 
     Returns ``(filtered_paths, used_git)``. When git isn't available the

--- a/sql_guard/python_scanner.py
+++ b/sql_guard/python_scanner.py
@@ -175,7 +175,9 @@ class _SqlCollector(cst.CSTVisitor if _LIBCST_AVAILABLE else object):
         if target is None:
             return
         if not (
-            isinstance(target, (cst.SimpleString, cst.ConcatenatedString, cst.FormattedString, cst.Name))
+            isinstance(
+                target, (cst.SimpleString, cst.ConcatenatedString, cst.FormattedString, cst.Name)
+            )
             or isinstance(target, cst.BinaryOperation)
             or _is_dot_format(target)
         ):

--- a/sql_guard/reporters/sarif.py
+++ b/sql_guard/reporters/sarif.py
@@ -17,8 +17,7 @@ from sql_guard.rules.python_rules import PYTHON_RULES
 
 INFO_URI = "https://github.com/Pawansingh3889/sql-guard"
 SARIF_SCHEMA = (
-    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/"
-    "sarif-schema-2.1.0.json"
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json"
 )
 
 
@@ -31,14 +30,16 @@ def _all_rule_descriptors() -> list[dict]:
     """Build the SARIF rule catalogue."""
     descriptors: list[dict] = []
     for rule in [*ALL_RULES, *PYTHON_RULES]:
-        descriptors.append({
-            "id": rule.id,
-            "name": rule.name,
-            "shortDescription": {"text": rule.description},
-            "fullDescription": {"text": rule.description},
-            "defaultConfiguration": {"level": _level(rule.severity)},
-            "helpUri": INFO_URI,
-        })
+        descriptors.append(
+            {
+                "id": rule.id,
+                "name": rule.name,
+                "shortDescription": {"text": rule.description},
+                "fullDescription": {"text": rule.description},
+                "defaultConfiguration": {"level": _level(rule.severity)},
+                "helpUri": INFO_URI,
+            }
+        )
     return descriptors
 
 
@@ -50,14 +51,16 @@ def build(result: CheckResult) -> dict:
             "ruleId": finding.rule_id,
             "level": _level(finding.severity),
             "message": {"text": finding.message},
-            "locations": [{
-                "physicalLocation": {
-                    "artifactLocation": {
-                        "uri": str(Path(finding.file).as_posix()),
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {
+                            "uri": str(Path(finding.file).as_posix()),
+                        },
+                        "region": {"startLine": max(1, finding.line)},
                     },
-                    "region": {"startLine": max(1, finding.line)},
-                },
-            }],
+                }
+            ],
         }
         if finding.suggestion:
             sarif_result["message"]["text"] += f" -- {finding.suggestion}"
@@ -66,17 +69,19 @@ def build(result: CheckResult) -> dict:
     return {
         "$schema": SARIF_SCHEMA,
         "version": "2.1.0",
-        "runs": [{
-            "tool": {
-                "driver": {
-                    "name": "sql-guard",
-                    "version": __version__,
-                    "informationUri": INFO_URI,
-                    "rules": _all_rule_descriptors(),
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "sql-guard",
+                        "version": __version__,
+                        "informationUri": INFO_URI,
+                        "rules": _all_rule_descriptors(),
+                    },
                 },
-            },
-            "results": results,
-        }],
+                "results": results,
+            }
+        ],
     }
 
 

--- a/sql_guard/rules/contracts.py
+++ b/sql_guard/rules/contracts.py
@@ -84,8 +84,7 @@ class ColumnNotInContract(ContractRule):
                         f"for table '{table_name}'"
                     ),
                     suggestion=(
-                        f"Either add '{ref_col}' to the contract or correct "
-                        f"the column name"
+                        f"Either add '{ref_col}' to the contract or correct the column name"
                     ),
                 )
         return None
@@ -162,9 +161,7 @@ class NotNullViolation(ContractRule):
         if table is None:
             return None
 
-        listed_cols = {
-            c.strip().strip("[]`\"").lower() for c in m.group(2).split(",")
-        }
+        listed_cols = {c.strip().strip('[]`"').lower() for c in m.group(2).split(",")}
         missing = [c for c in table.required_columns if c not in listed_cols]
 
         if missing:
@@ -216,9 +213,7 @@ class PrimaryKeyMissingOnInsert(ContractRule):
         if table is None or not table.primary_keys:
             return None
 
-        listed_cols = {
-            c.strip().strip("[]`\"").lower() for c in m.group(2).split(",")
-        }
+        listed_cols = {c.strip().strip('[]`"').lower() for c in m.group(2).split(",")}
         missing_pks = [
             pk
             for pk in table.primary_keys
@@ -274,8 +269,11 @@ class UnmappedForeignKey(ContractRule):
     )
 
     def _fk_resolves(
-        self, source_table_name: str, source_col: str,
-        target_table_name: str, target_col: str,
+        self,
+        source_table_name: str,
+        source_col: str,
+        target_table_name: str,
+        target_col: str,
     ) -> bool:
         if self.contract is None:
             return False
@@ -287,8 +285,7 @@ class UnmappedForeignKey(ContractRule):
             return False
         ref_table, _, ref_col = col.foreign_key.partition(".")
         return (
-            ref_table.lower() == target_table_name.lower()
-            and ref_col.lower() == target_col.lower()
+            ref_table.lower() == target_table_name.lower() and ref_col.lower() == target_col.lower()
         )
 
     def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:

--- a/sql_guard/rules/python_rules.py
+++ b/sql_guard/rules/python_rules.py
@@ -148,9 +148,7 @@ class SqlalchemyTextFstring(PythonRule):
                 file=file,
                 line=hit.line,
                 message="f-string passed to sqlalchemy.text() -- SQL injection risk",
-                suggestion=(
-                    "Use bound parameters: text(\"... WHERE id = :id\"), {\"id\": user_id}"
-                ),
+                suggestion=('Use bound parameters: text("... WHERE id = :id"), {"id": user_id}'),
             )
         return None
 

--- a/sql_guard/rules/structural.py
+++ b/sql_guard/rules/structural.py
@@ -7,6 +7,7 @@ regex misses, like implicit cross joins or deeply nested subqueries.
 Based on PyCon DE 2026: "Practical Refactoring with Syntax Trees" (Direr).
 Applies AST-based analysis to SQL instead of Python.
 """
+
 from __future__ import annotations
 
 import re

--- a/sql_guard/rules/structural.py
+++ b/sql_guard/rules/structural.py
@@ -9,6 +9,8 @@ Applies AST-based analysis to SQL instead of Python.
 """
 from __future__ import annotations
 
+import re
+
 from sql_guard.rules.base import Finding, Rule
 
 try:
@@ -20,11 +22,41 @@ except ImportError:
     HAS_SQLPARSE = False
 
 
+_SQL_STRING = re.compile(r"'(?:[^']|'')*'")
+_SQL_LINE_COMMENT = re.compile(r"--[^\n]*")
+_SQL_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _strip_strings_and_comments(text: str) -> str:
+    """Replace string literals and comments with empty equivalents.
+
+    Preserves character positions roughly (replaces strings with ``''`` and
+    comments with empty), so commas inside literals or comments do not
+    trigger comma-join detection but the surrounding structure is unchanged.
+    """
+    text = _SQL_STRING.sub("''", text)
+    text = _SQL_LINE_COMMENT.sub("", text)
+    text = _SQL_BLOCK_COMMENT.sub("", text)
+    return text
+
+
 class ImplicitCrossJoin(Rule):
     """S001: Implicit cross join via comma-separated tables in FROM.
 
-    SELECT * FROM orders, customers WHERE ...
-    is an implicit cross join. Use explicit JOIN syntax instead.
+    Detects ``SELECT * FROM orders, customers WHERE ...`` and the realistic
+    variants the older regex missed: aliased tables, schema-qualified
+    names, three-or-more-way joins, and multi-line layout. The scan walks
+    from each ``FROM`` keyword tracking parenthesis depth, stopping at
+    ``WHERE`` / ``GROUP BY`` / ``ORDER BY`` / ``HAVING`` / ``LIMIT`` /
+    ``UNION`` / ``EXCEPT`` / ``INTERSECT`` / explicit ``JOIN``, and flags
+    the first depth-0 comma it finds. Commas inside parenthesised
+    sub-expressions (function calls with multiple args, ``VALUES`` rows,
+    inline subqueries) do not trip the rule. Comma followed by
+    ``LATERAL`` is treated as a legitimate Snowflake/Postgres lateral
+    join and not flagged.
+
+    Suppress with an inline ``-- noqa: S001`` comment on the same line, or
+    use the project-wide ``-- sql-guard: disable=S001`` directive.
     """
 
     id = "S001"
@@ -33,18 +65,86 @@ class ImplicitCrossJoin(Rule):
     description = "Comma-separated tables in FROM clause create an implicit cross join"
     multiline = True
 
-    _from_pattern = Rule._compile(r"\bFROM\s+(\w+\s*,\s*\w+)")
+    _from_pattern = re.compile(r"\bFROM\b", re.IGNORECASE)
+    # Keywords that end the FROM clause. Scan stops here without flagging.
+    _stop_pattern = re.compile(
+        r"\b("
+        r"WHERE|"
+        r"GROUP\s+BY|ORDER\s+BY|HAVING|"
+        r"LIMIT|FETCH|OFFSET|"
+        r"INNER\s+JOIN|"
+        r"LEFT\s+(?:OUTER\s+)?JOIN|"
+        r"RIGHT\s+(?:OUTER\s+)?JOIN|"
+        r"FULL\s+(?:OUTER\s+)?JOIN|"
+        r"CROSS\s+JOIN|"
+        r"NATURAL\s+(?:INNER\s+|LEFT\s+|RIGHT\s+|FULL\s+)?JOIN|"
+        r"JOIN|"
+        r"UNION|EXCEPT|INTERSECT"
+        r")\b",
+        re.IGNORECASE,
+    )
+    # LATERAL after a comma is a real Snowflake/Postgres lateral join, not
+    # an implicit cross join. Skip past it.
+    _lateral_pattern = re.compile(r"\s*LATERAL\b", re.IGNORECASE)
 
     def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
-        if self._from_pattern.search(statement):
-            return Finding(
-                rule_id=self.id,
-                severity=self.severity,
-                file=file,
-                line=start_line,
-                message="Implicit cross join via comma-separated tables in FROM",
-                suggestion="Use explicit JOIN syntax: FROM orders JOIN customers ON ...",
-            )
+        cleaned = _strip_strings_and_comments(statement)
+        n = len(cleaned)
+
+        for from_match in self._from_pattern.finditer(cleaned):
+            # Skip "DELETE FROM" — single-target DELETE; Postgres uses
+            # "USING" for multi-table, MySQL has its own form. A bare
+            # comma after DELETE FROM is invalid syntax in most dialects,
+            # so we don't try to interpret it.
+            preceding = cleaned[: from_match.start()].rstrip().upper()
+            if preceding.endswith("DELETE"):
+                continue
+
+            depth = 0
+            i = from_match.end()
+            while i < n:
+                ch = cleaned[i]
+
+                if ch == "(":
+                    depth += 1
+                    i += 1
+                    continue
+                if ch == ")":
+                    depth -= 1
+                    if depth < 0:
+                        # Unbalanced — FROM was inside a subquery that
+                        # has now closed. Stop scanning this match.
+                        break
+                    i += 1
+                    continue
+
+                if depth != 0:
+                    i += 1
+                    continue
+
+                stop = self._stop_pattern.match(cleaned, i)
+                if stop:
+                    break
+
+                if ch == ";":
+                    break
+
+                if ch == ",":
+                    # Suppress for `, LATERAL ...` — valid lateral join.
+                    if self._lateral_pattern.match(cleaned, i + 1):
+                        i += 1
+                        continue
+                    line_offset = statement[:i].count("\n")
+                    return Finding(
+                        rule_id=self.id,
+                        severity=self.severity,
+                        file=file,
+                        line=start_line + line_offset,
+                        message="Implicit cross join via comma-separated tables in FROM",
+                        suggestion="Use explicit JOIN syntax: FROM a INNER JOIN b ON a.id = b.id",
+                    )
+
+                i += 1
         return None
 
 

--- a/sql_guard/rules/tsql.py
+++ b/sql_guard/rules/tsql.py
@@ -121,9 +121,7 @@ class DeprecatedOuterJoin(Rule):
 
     _pattern = Rule._compile(r"(?<![@\w])\w+\s*(?:\*=|=\*)\s*\w+")
 
-    def check_statement(
-        self, statement: str, start_line: int, file: str
-    ) -> Finding | None:
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
         if self._pattern.search(statement):
             return Finding(
                 rule_id=self.id,
@@ -156,9 +154,7 @@ class CreateIndexWithoutOnline(Rule):
     _pattern = Rule._compile(r"\bCREATE\s+(?:UNIQUE\s+)?(?:CLUSTERED\s+|NONCLUSTERED\s+)?INDEX\b")
     _has_online_on = Rule._compile(r"\bONLINE\s*=\s*ON\b")
 
-    def check_statement(
-        self, statement: str, start_line: int, file: str
-    ) -> Finding | None:
+    def check_statement(self, statement: str, start_line: int, file: str) -> Finding | None:
         if self._pattern.search(statement) and not self._has_online_on.search(statement):
             return Finding(
                 rule_id=self.id,

--- a/sql_guard/rules/warnings.py
+++ b/sql_guard/rules/warnings.py
@@ -248,8 +248,20 @@ class MixedCaseKeywords(Rule):
     multiline = False
 
     _keywords = [
-        "SELECT", "FROM", "WHERE", "JOIN", "INSERT", "UPDATE", "DELETE",
-        "CREATE", "DROP", "ALTER", "ORDER BY", "GROUP BY", "HAVING", "LIMIT",
+        "SELECT",
+        "FROM",
+        "WHERE",
+        "JOIN",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "CREATE",
+        "DROP",
+        "ALTER",
+        "ORDER BY",
+        "GROUP BY",
+        "HAVING",
+        "LIMIT",
     ]
 
     def check_line(self, line: str, line_number: int, file: str) -> Finding | None:
@@ -598,7 +610,9 @@ class WindowMissingPartition(Rule):
     id = "W013"
     name = "window-missing-partition"
     severity = "warning"
-    description = "OVER() without PARTITION BY may lead to unpredictable results and unclear intent."
+    description = (
+        "OVER() without PARTITION BY may lead to unpredictable results and unclear intent."
+    )
     multiline = True
 
     _over_pattern = Rule._compile(r"\bOVER\s*\(")
@@ -658,9 +672,7 @@ class ScalarUdfInWhere(Rule):
                     file=file,
                     line=start_line,
                     message="Scalar UDF in predicate forces row-by-row evaluation",
-                    suggestion=(
-                        "Inline the predicate, or use an inline TVF (CROSS APPLY) instead"
-                    ),
+                    suggestion=("Inline the predicate, or use an inline TVF (CROSS APPLY) instead"),
                 )
         return None
 

--- a/sql_guard/snapshot.py
+++ b/sql_guard/snapshot.py
@@ -27,13 +27,14 @@ def _require_sqlalchemy() -> Any:
         import sqlalchemy  # type: ignore[import-untyped]
     except ImportError as exc:
         raise SnapshotError(
-            "schema-snapshot requires SQLAlchemy. "
-            "Install with: pip install \"sql-sop[snapshot]\""
+            'schema-snapshot requires SQLAlchemy. Install with: pip install "sql-sop[snapshot]"'
         ) from exc
     return sqlalchemy
 
 
-def _column_to_dict(column: Any, primary_keys: set[str], fk_targets: dict[str, str]) -> dict[str, Any]:
+def _column_to_dict(
+    column: Any, primary_keys: set[str], fk_targets: dict[str, str]
+) -> dict[str, Any]:
     """Convert a SQLAlchemy column to the contract column dict shape."""
     out: dict[str, Any] = {"type": str(column.type)}
     if not column.nullable:

--- a/tests/fixtures/python_hazards.py
+++ b/tests/fixtures/python_hazards.py
@@ -3,6 +3,7 @@
 This file is never imported or executed by the package; it is read as text
 by the Python scanner. The SQL inside is synthetic and harmless.
 """
+
 from __future__ import annotations
 
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -109,9 +109,9 @@ class TestC001ColumnNotInContract:
     def test_handles_alias_or_table_name(self, contract):
         rule = ColumnNotInContract(contract=contract)
         # Bare table name (no alias) should still resolve.
-        assert (
-            _stmt(rule, "SELECT orders.id FROM orders;") is None
-        ), "table-name reference to a real column should pass"
+        assert _stmt(rule, "SELECT orders.id FROM orders;") is None, (
+            "table-name reference to a real column should pass"
+        )
         finding = _stmt(rule, "SELECT orders.bogus FROM orders;")
         assert finding is not None and finding.rule_id == "C001"
 
@@ -173,8 +173,7 @@ class TestC003NotNullViolation:
         assert (
             _stmt(
                 rule,
-                "INSERT INTO orders (customer_id, total, created_at) "
-                "VALUES (1, 99.99, NOW());",
+                "INSERT INTO orders (customer_id, total, created_at) VALUES (1, 99.99, NOW());",
             )
             is None
         )
@@ -202,8 +201,7 @@ class TestC004PrimaryKeyMissingOnInsert:
         assert (
             _stmt(
                 rule,
-                "INSERT INTO orders (customer_id, total, created_at) "
-                "VALUES (1, 99.99, NOW());",
+                "INSERT INTO orders (customer_id, total, created_at) VALUES (1, 99.99, NOW());",
             )
             is None
         )
@@ -247,20 +245,14 @@ class TestC005UnmappedForeignKey:
     def test_passes_when_fk_is_declared(self, contract):
         # contract_sample.yml has orders.customer_id -> customers.id
         rule = UnmappedForeignKey(contract=contract)
-        sql = (
-            "SELECT * FROM orders o "
-            "JOIN customers c ON o.customer_id = c.id;"
-        )
+        sql = "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id;"
         assert _stmt(rule, sql) is None
 
     def test_passes_when_fk_declared_other_direction(self, contract):
         # The contract declares the FK on customer_id; the JOIN order
         # writes c.id = o.customer_id. Should still resolve.
         rule = UnmappedForeignKey(contract=contract)
-        sql = (
-            "SELECT * FROM orders o "
-            "JOIN customers c ON c.id = o.customer_id;"
-        )
+        sql = "SELECT * FROM orders o JOIN customers c ON c.id = o.customer_id;"
         assert _stmt(rule, sql) is None
 
     def test_flags_join_with_no_declared_fk(self, contract):

--- a/tests/test_fluent.py
+++ b/tests/test_fluent.py
@@ -11,16 +11,12 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 class TestScanClean:
     def test_scan_clean_sql_passes(self) -> None:
-        result = SqlGuard().scan(
-            "SELECT id, name FROM users WHERE active = true LIMIT 10;"
-        )
+        result = SqlGuard().scan("SELECT id, name FROM users WHERE active = true LIMIT 10;")
         assert result.passed
         assert len(result.findings) == 0
 
     def test_result_bool_clean(self) -> None:
-        result = SqlGuard().scan(
-            "SELECT id, name FROM users WHERE active = true LIMIT 10;"
-        )
+        result = SqlGuard().scan("SELECT id, name FROM users WHERE active = true LIMIT 10;")
         assert bool(result) is True
 
 
@@ -52,9 +48,7 @@ class TestEnableFilter:
         assert "W002" not in rule_ids
 
     def test_enable_multiple(self) -> None:
-        result = SqlGuard().enable("E001", "W001").scan(
-            "DELETE FROM orders;\nSELECT * FROM users;"
-        )
+        result = SqlGuard().enable("E001", "W001").scan("DELETE FROM orders;\nSELECT * FROM users;")
         rule_ids = {f.rule_id for f in result.findings}
         assert rule_ids <= {"E001", "W001"}
 
@@ -121,9 +115,7 @@ class TestResultSummary:
         assert "1 file" in summary
 
     def test_result_summary_clean(self) -> None:
-        result = SqlGuard().scan(
-            "SELECT id FROM users WHERE active = true LIMIT 10;"
-        )
+        result = SqlGuard().scan("SELECT id FROM users WHERE active = true LIMIT 10;")
         summary = result.summary()
         assert "no issues" in summary
 
@@ -138,9 +130,7 @@ class TestResultSummary:
 
 class TestResultBool:
     def test_result_bool(self) -> None:
-        clean = SqlGuard().scan(
-            "SELECT id FROM users WHERE active = true LIMIT 10;"
-        )
+        clean = SqlGuard().scan("SELECT id FROM users WHERE active = true LIMIT 10;")
         assert bool(clean) is True
 
         dirty = SqlGuard().scan("DELETE FROM orders;")
@@ -150,7 +140,5 @@ class TestResultBool:
         result = SqlGuard().scan("DELETE FROM orders;")
         assert len(result) > 0
 
-        clean = SqlGuard().scan(
-            "SELECT id FROM users WHERE active = true LIMIT 10;"
-        )
+        clean = SqlGuard().scan("SELECT id FROM users WHERE active = true LIMIT 10;")
         assert len(clean) == 0

--- a/tests/test_inline_disable.py
+++ b/tests/test_inline_disable.py
@@ -47,10 +47,7 @@ def test_parse_case_insensitive_ids():
 
 def test_check_file_respects_inline_disable(tmp_path: Path):
     sql = tmp_path / "demo.sql"
-    sql.write_text(
-        "SELECT * FROM t; -- sql-guard: disable=W001\n"
-        "SELECT * FROM other;\n"
-    )
+    sql.write_text("SELECT * FROM t; -- sql-guard: disable=W001\nSELECT * FROM other;\n")
     findings = check_file(sql, ALL_RULES)
     w001 = [f for f in findings if f.rule_id == "W001"]
     # Line 1 is suppressed; line 2 still fires.
@@ -60,9 +57,6 @@ def test_check_file_respects_inline_disable(tmp_path: Path):
 
 def test_check_file_respects_disable_next_line(tmp_path: Path):
     sql = tmp_path / "demo.sql"
-    sql.write_text(
-        "-- sql-guard: disable-next-line=W001\n"
-        "SELECT * FROM t;\n"
-    )
+    sql.write_text("-- sql-guard: disable-next-line=W001\nSELECT * FROM t;\n")
     findings = check_file(sql, ALL_RULES)
     assert not any(f.rule_id == "W001" for f in findings)

--- a/tests/test_new_rules.py
+++ b/tests/test_new_rules.py
@@ -35,10 +35,13 @@ def test_e007_flags_add_not_null_without_default():
 
 def test_e007_passes_when_default_supplied():
     rule = AlterAddNotNullNoDefault()
-    assert _stmt(
-        rule,
-        "ALTER TABLE orders ADD status VARCHAR(20) NOT NULL DEFAULT 'NEW';",
-    ) is None
+    assert (
+        _stmt(
+            rule,
+            "ALTER TABLE orders ADD status VARCHAR(20) NOT NULL DEFAULT 'NEW';",
+        )
+        is None
+    )
 
 
 def test_e007_passes_when_column_is_nullable():
@@ -131,18 +134,24 @@ def test_t005_flags_basic_create_index():
 
 def test_t005_passes_with_online_on():
     rule = CreateIndexWithoutOnline()
-    assert _stmt(
-        rule,
-        "CREATE INDEX ix_orders_date ON orders (order_date) WITH (ONLINE = ON);",
-    ) is None
+    assert (
+        _stmt(
+            rule,
+            "CREATE INDEX ix_orders_date ON orders (order_date) WITH (ONLINE = ON);",
+        )
+        is None
+    )
 
 
 def test_t005_flags_clustered_unique_variants():
     rule = CreateIndexWithoutOnline()
-    assert _stmt(
-        rule,
-        "CREATE UNIQUE NONCLUSTERED INDEX ix ON orders (id);",
-    ) is not None
+    assert (
+        _stmt(
+            rule,
+            "CREATE UNIQUE NONCLUSTERED INDEX ix ON orders (id);",
+        )
+        is not None
+    )
 
 
 # W019 count-distinct-unbounded -----------------------------------------------
@@ -180,10 +189,7 @@ def test_w019_passes_with_group_by():
 
 def test_w019_passes_with_limit():
     rule = CountDistinctUnbounded()
-    assert (
-        _stmt(rule, "SELECT COUNT(DISTINCT user_id) FROM events LIMIT 1;")
-        is None
-    )
+    assert _stmt(rule, "SELECT COUNT(DISTINCT user_id) FROM events LIMIT 1;") is None
 
 
 def test_w019_handles_whitespace_in_count_distinct():
@@ -285,9 +291,7 @@ def test_w015_flags_upper_function_in_join_on():
     from sql_guard.rules.warnings import JoinFunctionOnColumn
 
     rule = JoinFunctionOnColumn()
-    finding = _line(
-        rule, "JOIN customers c ON UPPER(o.email) = UPPER(c.email)"
-    )
+    finding = _line(rule, "JOIN customers c ON UPPER(o.email) = UPPER(c.email)")
     assert finding is not None
     assert finding.rule_id == "W015"
     assert finding.severity == "warning"
@@ -306,9 +310,7 @@ def test_w015_passes_when_join_uses_materialized_columns():
     from sql_guard.rules.warnings import JoinFunctionOnColumn
 
     rule = JoinFunctionOnColumn()
-    assert _line(
-        rule, "JOIN customers c ON o.email_lower = c.email_lower"
-    ) is None
+    assert _line(rule, "JOIN customers c ON o.email_lower = c.email_lower") is None
 
 
 def test_w015_does_not_flag_function_in_where_only():
@@ -352,10 +354,7 @@ def test_w022_flags_cross_join_case_insensitive():
 
 def test_w022_passes_regular_inner_join():
     rule = CrossJoinExplicit()
-    assert (
-        _line(rule, "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id;")
-        is None
-    )
+    assert _line(rule, "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id;") is None
 
 
 def test_w022_passes_left_join():

--- a/tests/test_python_scanner.py
+++ b/tests/test_python_scanner.py
@@ -112,11 +112,7 @@ class TestPythonRules:
     def test_safe_parameterised_produces_no_p_findings(self) -> None:
         # The safe_parameterised function uses a literal SQL with a tuple
         # param — P-rules should not fire for it.
-        hits = [
-            h
-            for h in python_scanner.extract_from_file(PY_FIXTURE)
-            if "WHERE id = ?" in h.sql
-        ]
+        hits = [h for h in python_scanner.extract_from_file(PY_FIXTURE) if "WHERE id = ?" in h.sql]
         assert hits, "safe literal should be extracted"
         for hit in hits:
             assert hit.kind == "literal"

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -133,11 +133,7 @@ class TestWarningRules:
         from sql_guard.rules.warnings import HavingWithoutGroupBy
 
         rule = HavingWithoutGroupBy()
-        statement = (
-            "SELECT status, COUNT(*) FROM orders\n"
-            "-- GROUP BY status\n"
-            "HAVING COUNT(*) > 10;"
-        )
+        statement = "SELECT status, COUNT(*) FROM orders\n-- GROUP BY status\nHAVING COUNT(*) > 10;"
         assert rule.check_statement(statement, 1, "test.sql") is not None
 
     def test_w021_ignores_group_by_in_subquery_before_outer_having(self) -> None:
@@ -203,8 +199,10 @@ class TestWarningRules:
         from sql_guard.rules.warnings import WindowMissingPartition
 
         rule = WindowMissingPartition()
-        statement = "SELECT ROW_NUMBER() OVER (PARTITION BY department_id ORDER BY id) AS rn FROM users;"
-    
+        statement = (
+            "SELECT ROW_NUMBER() OVER (PARTITION BY department_id ORDER BY id) AS rn FROM users;"
+        )
+
         assert rule.check_statement(statement, 1, "test.sql") is None
 
     def test_w016_not_in_with_subquery(self) -> None:
@@ -241,9 +239,7 @@ class TestWarningRules:
         w014 = [f for f in result.findings if f.rule_id == "W014"]
         assert not w014
 
-    def test_w014_outer_case_without_else_fires_when_inner_has_else(
-        self, tmp_path
-    ) -> None:
+    def test_w014_outer_case_without_else_fires_when_inner_has_else(self, tmp_path) -> None:
         # Issue #4 specifically called out the nested case: an outer
         # CASE with no ELSE must still fire even when an inner CASE
         # does have one.
@@ -251,10 +247,7 @@ class TestWarningRules:
 
         rule = CaseWithoutElse()
         nested = (
-            "SELECT CASE\n"
-            "  WHEN x THEN CASE WHEN y THEN 1 ELSE 2 END\n"
-            "  WHEN z THEN 3\n"
-            "END FROM t;"
+            "SELECT CASE\n  WHEN x THEN CASE WHEN y THEN 1 ELSE 2 END\n  WHEN z THEN 3\nEND FROM t;"
         )
         finding = rule.check_statement(nested, 1, "test.sql")
         assert finding is not None

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -49,9 +49,7 @@ def test_sarif_emits_each_finding():
 
 
 def test_sarif_render_returns_valid_json():
-    finding = Finding(
-        rule_id="E001", severity="error", file="x.sql", line=1, message="m"
-    )
+    finding = Finding(rule_id="E001", severity="error", file="x.sql", line=1, message="m")
     blob = sarif_reporter.render(_result(finding))
     parsed = json.loads(blob)
     assert parsed["runs"][0]["results"][0]["ruleId"] == "E001"
@@ -59,8 +57,8 @@ def test_sarif_render_returns_valid_json():
 
 def test_sarif_clamps_line_zero_to_one():
     # SARIF requires startLine >= 1; system findings with line=0 must be normalised.
-    finding = Finding(
-        rule_id="SYS", severity="error", file="x.sql", line=0, message="cannot read"
-    )
+    finding = Finding(rule_id="SYS", severity="error", file="x.sql", line=0, message="cannot read")
     doc = sarif_reporter.build(_result(finding))
-    assert doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]["startLine"] == 1
+    assert (
+        doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]["startLine"] == 1
+    )

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -26,6 +26,116 @@ class TestImplicitCrossJoin:
         result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
         assert result is None
 
+    # Regression: previous regex missed any FROM with table aliases.
+    def test_comma_join_with_aliases_detected(self) -> None:
+        sql = "SELECT * FROM orders o, customers c WHERE o.cust_id = c.id"
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is not None
+        assert result.rule_id == "S001"
+
+    # Regression: previous regex missed schema-qualified table names.
+    def test_comma_join_with_schema_qualified_detected(self) -> None:
+        sql = (
+            "SELECT * FROM raw.orders, raw.customers "
+            "WHERE raw.orders.cust_id = raw.customers.id"
+        )
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is not None
+        assert result.rule_id == "S001"
+
+    # Regression: previous regex missed three-or-more-way comma joins.
+    def test_comma_join_three_tables_detected(self) -> None:
+        sql = (
+            "SELECT * FROM orders o, customers c, products p "
+            "WHERE o.cust_id = c.id AND o.product_id = p.id"
+        )
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is not None
+        assert result.rule_id == "S001"
+
+    # Regression: previous regex missed multi-line FROM clauses.
+    def test_comma_join_multiline_detected(self) -> None:
+        sql = (
+            "SELECT *\n"
+            "FROM orders o,\n"
+            "     customers c\n"
+            "WHERE o.cust_id = c.id"
+        )
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is not None
+        assert result.rule_id == "S001"
+
+    # Function call with comma-separated args is not a comma-join.
+    def test_function_call_with_comma_args_passes(self) -> None:
+        sql = "SELECT SPLIT_TO_ARRAY(s, ',') FROM events"
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is None
+
+    # Subquery with comma in SELECT list is not a comma-join.
+    def test_subquery_with_comma_in_select_passes(self) -> None:
+        sql = "SELECT * FROM (SELECT a, b, c FROM t) AS sub"
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is None
+
+    # VALUES with multiple rows is not a comma-join.
+    def test_values_clause_passes(self) -> None:
+        sql = "SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS v(id, label)"
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is None
+
+    # Snowflake / Postgres LATERAL after a comma is a real lateral join.
+    def test_snowflake_lateral_flatten_passes(self) -> None:
+        sql = "SELECT * FROM events e, LATERAL FLATTEN(input => e.tags) AS f"
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is None
+
+    def test_postgres_lateral_passes(self) -> None:
+        sql = (
+            "SELECT * FROM t1 t, "
+            "LATERAL (SELECT * FROM t2 WHERE t2.id = t.id) AS sub"
+        )
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is None
+
+    # LEFT/RIGHT/FULL OUTER JOIN should not flag.
+    def test_left_outer_join_passes(self) -> None:
+        sql = "SELECT * FROM orders o LEFT OUTER JOIN customers c ON o.cust_id = c.id"
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is None
+
+    # String literal containing comma in WHERE is not a comma-join.
+    def test_string_literal_with_comma_passes(self) -> None:
+        sql = "SELECT * FROM orders WHERE customer = 'Smith, J'"
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is None
+
+    # DELETE FROM single table should not flag.
+    def test_delete_from_passes(self) -> None:
+        sql = "DELETE FROM orders WHERE id = 1"
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is None
+
+    # Comments between tables are stripped before scanning.
+    def test_comment_between_tables_still_detected(self) -> None:
+        sql = (
+            "SELECT * FROM orders o, /* legacy joined here */ customers c "
+            "WHERE o.cust_id = c.id"
+        )
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is not None
+        assert result.rule_id == "S001"
+
+    # Comma-join inside a CTE is detected.
+    def test_comma_join_inside_cte_detected(self) -> None:
+        sql = (
+            "WITH joined AS ("
+            "  SELECT * FROM orders o, customers c WHERE o.cust_id = c.id"
+            ") SELECT * FROM joined"
+        )
+        result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
+        assert result is not None
+        assert result.rule_id == "S001"
+
 
 class TestDeeplyNestedSubquery:
     def test_shallow_passes(self) -> None:

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -1,4 +1,5 @@
 """Tests for structural rules (S001-S003)."""
+
 from __future__ import annotations
 
 
@@ -35,10 +36,7 @@ class TestImplicitCrossJoin:
 
     # Regression: previous regex missed schema-qualified table names.
     def test_comma_join_with_schema_qualified_detected(self) -> None:
-        sql = (
-            "SELECT * FROM raw.orders, raw.customers "
-            "WHERE raw.orders.cust_id = raw.customers.id"
-        )
+        sql = "SELECT * FROM raw.orders, raw.customers WHERE raw.orders.cust_id = raw.customers.id"
         result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
         assert result is not None
         assert result.rule_id == "S001"
@@ -55,12 +53,7 @@ class TestImplicitCrossJoin:
 
     # Regression: previous regex missed multi-line FROM clauses.
     def test_comma_join_multiline_detected(self) -> None:
-        sql = (
-            "SELECT *\n"
-            "FROM orders o,\n"
-            "     customers c\n"
-            "WHERE o.cust_id = c.id"
-        )
+        sql = "SELECT *\nFROM orders o,\n     customers c\nWHERE o.cust_id = c.id"
         result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
         assert result is not None
         assert result.rule_id == "S001"
@@ -90,10 +83,7 @@ class TestImplicitCrossJoin:
         assert result is None
 
     def test_postgres_lateral_passes(self) -> None:
-        sql = (
-            "SELECT * FROM t1 t, "
-            "LATERAL (SELECT * FROM t2 WHERE t2.id = t.id) AS sub"
-        )
+        sql = "SELECT * FROM t1 t, LATERAL (SELECT * FROM t2 WHERE t2.id = t.id) AS sub"
         result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
         assert result is None
 
@@ -117,10 +107,7 @@ class TestImplicitCrossJoin:
 
     # Comments between tables are stripped before scanning.
     def test_comment_between_tables_still_detected(self) -> None:
-        sql = (
-            "SELECT * FROM orders o, /* legacy joined here */ customers c "
-            "WHERE o.cust_id = c.id"
-        )
+        sql = "SELECT * FROM orders o, /* legacy joined here */ customers c WHERE o.cust_id = c.id"
         result = ImplicitCrossJoin().check_statement(sql, 1, "test.sql")
         assert result is not None
         assert result.rule_id == "S001"

--- a/tests/test_tsql.py
+++ b/tests/test_tsql.py
@@ -116,10 +116,7 @@ def test_t004_does_not_flag_plain_assignment():
 
 def test_t004_does_not_flag_modern_joins():
     rule = DeprecatedOuterJoin()
-    assert (
-        _check_statement(rule, "SELECT * FROM a LEFT OUTER JOIN b ON a.id = b.id")
-        is None
-    )
+    assert _check_statement(rule, "SELECT * FROM a LEFT OUTER JOIN b ON a.id = b.id") is None
 
 
 # W002 / W006 FETCH NEXT regression coverage


### PR DESCRIPTION
Closes #41.

S001 (`implicit-cross-join`) already exists, but the detection regex `\bFROM\s+(\w+\s*,\s*\w+)` only matches when the comma comes immediately after the first word after `FROM`. Most real-world comma-joins slip through silently.

Reproductions on `main` (none of these flag):

```sql
SELECT * FROM orders o, customers c WHERE o.cust_id = c.id;
SELECT * FROM raw.orders, raw.customers WHERE raw.orders.cust_id = raw.customers.id;
SELECT * FROM o1, o2, o3 WHERE o1.id = o2.id AND o2.id = o3.id;
SELECT *
FROM orders o,
     customers c
WHERE o.cust_id = c.id;
```

Replaces the regex with a paren-depth-aware scan. From each `FROM` keyword, walk forward tracking parenthesis depth, stop at `WHERE` / `GROUP BY` / `ORDER BY` / `HAVING` / `LIMIT` / `FETCH` / `OFFSET` / explicit `JOIN` (all variants) / `UNION` / `EXCEPT` / `INTERSECT`, and flag the first depth-0 comma. Strings and comments are stripped first so commas inside literals or comments do not trigger.

Two deliberate suppression cases. `DELETE FROM` is skipped because a single-target DELETE is the normal case in standard SQL and bare `DELETE FROM x, y` is invalid in Postgres, SQL Server, and MySQL. Comma followed by `LATERAL` is recognised as a legitimate Snowflake / Postgres lateral join and not flagged, so `FROM events e, LATERAL FLATTEN(input => e.tags)` and `FROM t1, LATERAL (SELECT ...)` both pass.

Why fix S001 rather than ship a duplicate W027: the rule already existed and was simply not catching the patterns it claimed to cover. Adding W027 would have left the buggy S001 in place. Closing #41 here.

Tests: 14 new regression cases under `TestImplicitCrossJoin` covering aliases, schema-qualified names, three-or-more-way joins, multi-line layout, comma-join inside CTE, plus all the suppression cases. Test class size goes from 3 to 17. Full suite: 226 pass and 1 skipped, no regressions.

CHANGELOG entry added under `[Unreleased]` `Fixed`.

Commits signed (ED25519).