### PR TITLE
chore: exclude test fixtures from the sql-sop dogfooding pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,11 +37,16 @@ repos:
       - id: ruff-format
 
   # ── sql-sop dogfooding itself ─────────────────────────────────────
-  # Runs sql-sop on the project's own fixtures + any staged .sql files
-  # so a regression in a rule is caught before it ships.
+  # Runs sql-sop on staged .sql files so a regression in a rule is
+  # caught before it ships. Test fixtures under ``tests/fixtures/`` are
+  # excluded because those files deliberately contain bad SQL
+  # (E001..E006, S001..S003, etc.) to drive the rule unit tests --
+  # running the linter against them is guaranteed to fail and was
+  # turning pre-commit.ci red on every PR.
   - repo: https://github.com/Pawansingh3889/sql-guard
     rev: v0.7.0
     hooks:
       - id: sql-sop
         args: [--severity, error]
         files: \.sql$
+        exclude: ^tests/fixtures/


### PR DESCRIPTION
## Why

The sql-sop dogfooding hook in `.pre-commit-config.yaml` ran `sql-sop --severity error` on every `*.sql` file in the repo. The only SQL files in the repo are unit-test fixtures under `tests/fixtures/`, and those fixtures **deliberately contain bad SQL** so the rule unit tests can assert on them (E001 DELETE without WHERE, E002 DROP without IF EXISTS, etc.).

Result: pre-commit.ci has been red on every PR with `Found 6 issues (6 errors) in 1 file`. The failure was hidden behind the also-always-red validate check (just fixed by #50); on PRs that don't touch SQL fixtures the dogfooding adds no diagnostic value because the failures are by design.

## Fix

Add `exclude: ^tests/fixtures/` to the hook so it only runs against real SQL files outside the fixtures tree. There are no real `.sql` files in the repo today, so the hook is effectively dormant -- it kicks in the moment someone adds a migration script, an example query, or a scratch file outside `tests/fixtures/`.

The rule unit tests in `tests/test_rules.py` (and similar) continue to consume those fixtures via pytest as before.