### PR TITLE
feat: dbt-aware rule pack scaffolding + DBT001 model-without-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ a deprecation window (see `GOVERNANCE.md` § Scope discipline).
 
 ### Added
 
+- **DBT001 `model-without-test`** - first rule in the dbt-aware rule
+  pack. Fires once per `.sql` file inside the project's `model-paths`
+  when the model has no `tests:` (dbt <=1.4) or `data_tests:`
+  (dbt >=1.5) entry in any `schema.yml`. Activated by the new `--dbt`
+  CLI flag; silent without it. Models outside `model-paths` (macros,
+  analyses, snapshots) and non-SQL files are skipped. See the
+  [dbt-aware rule pack ADR] for the broader rule set roadmap.
+
+  This release also lands the scaffolding the rest of the pack will
+  build on:
+  - `sql_guard.dbt` module: walks up to find `dbt_project.yml`,
+    reads `model-paths`, and parses `schema.yml` files into a
+    `DbtProject` value object. Tolerates malformed schema.yml
+    without crashing the lint run.
+  - `Rule.check_file` extension point: a file-level check hook on the
+    base rule class. Default returns an empty list so existing
+    line- and statement-rules pay nothing.
+  - `--dbt` CLI flag and `build_dbt_rules(project)` registry helper
+    that mirror the Contracts Pack opt-in pattern.
+
+  Jinja preprocessing and the remaining six rules in the ADR are
+  intentionally deferred to follow-up PRs.
+
 - **W021 `having-without-group-by`** - warns when `HAVING` appears
   without a preceding `GROUP BY` in the same query block. The query
   becomes a single implicit group, almost always a typo for `WHERE`.

--- a/sql_guard/checker.py
+++ b/sql_guard/checker.py
@@ -181,6 +181,17 @@ def check_file(
                     if fail_fast and finding.severity == "error":
                         return findings
 
+    # Pass 3: file-level rules. Default ``check_file`` returns an empty
+    # list so line- and statement-rules pay nothing here. File-level
+    # rules (e.g. the dbt-aware pack) override it.
+    for rule in rules:
+        for finding in rule.check_file(file_str):
+            if disables.is_disabled(finding.line, finding.rule_id):
+                continue
+            findings.append(finding)
+            if fail_fast and finding.severity == "error":
+                return findings
+
     return findings
 
 

--- a/sql_guard/checker.py
+++ b/sql_guard/checker.py
@@ -289,9 +289,7 @@ def check(
         CheckResult with all findings.
     """
     t0 = time.perf_counter()
-    rules = get_rules(
-        disabled_ids=disabled_rules, contract=contract, dbt_project=dbt_project
-    )
+    rules = get_rules(disabled_ids=disabled_rules, contract=contract, dbt_project=dbt_project)
     discovered = discover_files(paths, ignore=ignore, include_python=include_python)
 
     result = CheckResult()

--- a/sql_guard/checker.py
+++ b/sql_guard/checker.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from sql_guard.contracts import Contract
+from sql_guard.dbt import DbtProject
 from sql_guard.rules import get_rules
 from sql_guard.rules.base import Finding, Rule
 from sql_guard.rules.python_rules import PYTHON_RULES
@@ -268,6 +269,7 @@ def check(
     ignore: list[str] | None = None,
     include_python: bool = False,
     contract: Contract | None = None,
+    dbt_project: "DbtProject | None" = None,  # noqa: F821 -- imported below
 ) -> CheckResult:
     """Run all rules against discovered SQL (and optionally Python) files.
 
@@ -280,12 +282,16 @@ def check(
         include_python: Also scan ``.py`` files for embedded SQL via libCST.
         contract: Optional data contract. When provided, contract-aware rules
             (C001-...) are activated and given this contract instance.
+        dbt_project: Optional discovered dbt project. When provided,
+            dbt-aware rules (DBT001-...) are activated and given this project.
 
     Returns:
         CheckResult with all findings.
     """
     t0 = time.perf_counter()
-    rules = get_rules(disabled_ids=disabled_rules, contract=contract)
+    rules = get_rules(
+        disabled_ids=disabled_rules, contract=contract, dbt_project=dbt_project
+    )
     discovered = discover_files(paths, ignore=ignore, include_python=include_python)
 
     result = CheckResult()

--- a/sql_guard/cli.py
+++ b/sql_guard/cli.py
@@ -129,9 +129,7 @@ def check_cmd(
             try:
                 dbt_project = load_dbt_project(project_yml)
             except Exception as exc:
-                console.print(
-                    f"[red]Failed to load dbt project {project_yml}:[/red] {exc}"
-                )
+                console.print(f"[red]Failed to load dbt project {project_yml}:[/red] {exc}")
                 raise typer.Exit(code=2)
 
     if changed_only:

--- a/sql_guard/cli.py
+++ b/sql_guard/cli.py
@@ -13,6 +13,7 @@ from rich.table import Table
 from sql_guard import __version__, config as config_mod
 from sql_guard.checker import check, discover_files
 from sql_guard.contracts import Contract
+from sql_guard.dbt import DbtProject, find_dbt_project, load_dbt_project
 from sql_guard.git_filter import filter_to_changed
 from sql_guard.reporters import sarif as sarif_reporter
 from sql_guard.reporters.terminal import print_result
@@ -78,6 +79,15 @@ def check_cmd(
             "lint queries against the declared schema."
         ),
     ),
+    dbt: bool = typer.Option(
+        False,
+        "--dbt",
+        help=(
+            "Activate the dbt-aware rule pack (DBT001-). Walks up from the "
+            "first checked path to find dbt_project.yml; falls back silently "
+            "if no project is found."
+        ),
+    ),
 ) -> None:
     """Check SQL files for common issues."""
     if not paths:
@@ -106,6 +116,24 @@ def check_cmd(
             console.print(f"[red]Failed to load contract {effective_contract_path}:[/red] {exc}")
             raise typer.Exit(code=2)
 
+    dbt_project: Optional[DbtProject] = None
+    if dbt:
+        start = Path(paths[0]) if paths else Path(".")
+        project_yml = find_dbt_project(start)
+        if project_yml is None:
+            console.print(
+                "[yellow]--dbt: no dbt_project.yml found walking up from "
+                f"{start}; dbt-aware rules are silent.[/yellow]"
+            )
+        else:
+            try:
+                dbt_project = load_dbt_project(project_yml)
+            except Exception as exc:
+                console.print(
+                    f"[red]Failed to load dbt project {project_yml}:[/red] {exc}"
+                )
+                raise typer.Exit(code=2)
+
     if changed_only:
         discovered = discover_files(
             paths, ignore=effective_ignore, include_python=effective_include_python
@@ -130,6 +158,7 @@ def check_cmd(
         ignore=effective_ignore,
         include_python=effective_include_python,
         contract=contract,
+        dbt_project=dbt_project,
     )
 
     if output_format == "sarif":

--- a/sql_guard/dbt.py
+++ b/sql_guard/dbt.py
@@ -1,0 +1,13 @@
+"""dbt project discovery helpers.
+
+When sql-sop is invoked with ``--dbt`` it needs to know where the dbt
+project lives so it can read ``dbt_project.yml`` and any ``schema.yml``
+files. This module owns that discovery. It does not parse Jinja or run
+any rule logic; rules in :mod:`sql_guard.rules.dbt` consume the
+:class:`DbtProject` it produces.
+
+Scope discipline: static reads only. No subprocess, no ``dbt compile``,
+no DB connection. See the dbt-aware rule pack ADR for the rationale.
+"""
+
+from __future__ import annotations

--- a/sql_guard/dbt.py
+++ b/sql_guard/dbt.py
@@ -11,3 +11,130 @@ no DB connection. See the dbt-aware rule pack ADR for the rationale.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+# Default model-paths used by dbt when the key is absent from
+# dbt_project.yml. Matches dbt's own default ("models") as of dbt 1.7.
+_DEFAULT_MODEL_PATHS = ("models",)
+
+
+@dataclass(frozen=True)
+class DbtModelEntry:
+    """A model declaration read from a ``schema.yml`` file.
+
+    Only the fields the dbt-aware rule pack actually reads are captured.
+    Anything else in the YAML is ignored. Extending this is cheap when a
+    new rule needs another field.
+    """
+
+    name: str
+    has_tests: bool
+    description: str | None
+    source_file: Path
+
+
+@dataclass(frozen=True)
+class DbtProject:
+    """A discovered dbt project.
+
+    ``root`` is the directory containing ``dbt_project.yml``.
+    ``model_paths`` are absolute paths to the configured model dirs.
+    ``models`` is the merged set of model entries across every
+    ``schema.yml`` found under ``model_paths``.
+    """
+
+    root: Path
+    model_paths: tuple[Path, ...]
+    models: tuple[DbtModelEntry, ...] = field(default_factory=tuple)
+
+
+def find_dbt_project(start: Path) -> Path | None:
+    """Walk up from ``start`` looking for ``dbt_project.yml``.
+
+    Returns the absolute path to the YAML file, or ``None`` if no
+    ``dbt_project.yml`` is found before reaching the filesystem root.
+
+    ``start`` may be either a file or a directory. If a file is given
+    the search begins in its parent directory.
+    """
+    current = start.resolve()
+    if current.is_file():
+        current = current.parent
+    while True:
+        candidate = current / "dbt_project.yml"
+        if candidate.is_file():
+            return candidate
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def load_dbt_project(project_yml: Path) -> DbtProject:
+    """Read ``dbt_project.yml`` and discover models under model-paths.
+
+    Parses the YAML, resolves ``model-paths`` (falling back to dbt's
+    default of ``models``), then walks each model dir for
+    ``schema.yml`` files and pulls model entries out of them.
+
+    The function is forgiving: a malformed ``schema.yml`` produces an
+    empty contribution rather than raising. Linting must not crash
+    because somebody left a comment-only stub in their schema.yml.
+    """
+    project_yml = project_yml.resolve()
+    root = project_yml.parent
+
+    with project_yml.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    raw_paths = data.get("model-paths") or list(_DEFAULT_MODEL_PATHS)
+    model_paths = tuple((root / rel).resolve() for rel in raw_paths)
+
+    models: list[DbtModelEntry] = []
+    for model_dir in model_paths:
+        if not model_dir.is_dir():
+            continue
+        for schema_file in model_dir.rglob("schema.yml"):
+            models.extend(_read_schema_yml(schema_file))
+
+    return DbtProject(root=root, model_paths=model_paths, models=tuple(models))
+
+
+def _read_schema_yml(schema_file: Path) -> list[DbtModelEntry]:
+    """Parse one ``schema.yml`` into ``DbtModelEntry`` rows.
+
+    Models without a ``name`` key are skipped (malformed). A model is
+    considered to have tests if it carries either a top-level ``tests``
+    key (dbt <=1.4 spelling) or a ``data_tests`` key (dbt >=1.5
+    spelling). The dbt-aware rule pack accepts both.
+    """
+    try:
+        with schema_file.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except yaml.YAMLError:
+        return []
+
+    entries: list[DbtModelEntry] = []
+    for model in data.get("models") or []:
+        if not isinstance(model, dict):
+            continue
+        name = model.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        has_tests = bool(model.get("tests") or model.get("data_tests"))
+        description = model.get("description")
+        if description is not None and not isinstance(description, str):
+            description = str(description)
+        entries.append(
+            DbtModelEntry(
+                name=name,
+                has_tests=has_tests,
+                description=description,
+                source_file=schema_file,
+            )
+        )
+    return entries

--- a/sql_guard/rules/__init__.py
+++ b/sql_guard/rules/__init__.py
@@ -126,20 +126,38 @@ ALL_RULES: list[Rule] = [
 ]
 
 
+def build_dbt_rules(project: "DbtProject") -> list[Rule]:  # noqa: F821 -- forward reference
+    """Construct the dbt-aware rule pack with a discovered project.
+
+    Each rule needs the project to look up schema.yml entries, model
+    paths, etc. The pack is opt-in via the ``--dbt`` CLI flag, so this
+    helper is only invoked when a project was actually discovered.
+    """
+    from sql_guard.rules.dbt import ModelWithoutTest
+
+    return [ModelWithoutTest(project)]
+
+
 def get_rules(
     enabled_ids: set[str] | None = None,
     disabled_ids: set[str] | None = None,
     contract: "Contract | None" = None,  # noqa: F821 -- forward reference
+    dbt_project: "DbtProject | None" = None,  # noqa: F821 -- forward reference
 ) -> list[Rule]:
     """Return filtered list of rules based on config.
 
     If ``contract`` is provided, contract-aware rules (C001-...) are
     instantiated with that contract and appended. Without a contract they
     are silent and not registered.
+
+    If ``dbt_project`` is provided, dbt-aware rules (DBT001-...) are
+    instantiated with that project and appended. Same opt-in shape.
     """
     rules = list(ALL_RULES)
     if contract is not None:
         rules = rules + list(build_contract_rules(contract))
+    if dbt_project is not None:
+        rules = rules + list(build_dbt_rules(dbt_project))
     if enabled_ids:
         rules = [r for r in rules if r.id in enabled_ids]
     if disabled_ids:
@@ -147,5 +165,6 @@ def get_rules(
     return rules
 
 
-# Forward import for type hints; placed at bottom to avoid circular import.
+# Forward imports for type hints; placed at bottom to avoid circular imports.
 from sql_guard.contracts import Contract  # noqa: E402, F401
+from sql_guard.dbt import DbtProject  # noqa: E402, F401

--- a/sql_guard/rules/base.py
+++ b/sql_guard/rules/base.py
@@ -60,6 +60,16 @@ class Rule:
         """Check a full SQL statement. Override for multi-line rules."""
         return None
 
+    def check_file(self, file: str) -> list[Finding]:
+        """Check a whole file once. Override for file-level rules.
+
+        Returns a list so a single file-level rule can produce multiple
+        findings in one pass (a project-aware rule fires once per
+        offending model, for example). Default is an empty list so
+        existing line / statement rules pay nothing.
+        """
+        return []
+
     @staticmethod
     def _compile(pattern: str) -> re.Pattern:
         """Compile a regex pattern with IGNORECASE. Called once at init."""

--- a/sql_guard/rules/dbt.py
+++ b/sql_guard/rules/dbt.py
@@ -12,3 +12,87 @@ Severity split, per the ADR:
 """
 
 from __future__ import annotations
+
+from pathlib import Path
+
+from sql_guard.dbt import DbtProject
+from sql_guard.rules.base import Finding, Rule
+
+
+class ModelWithoutTest(Rule):
+    """DBT001: dbt model has no ``tests:`` entry in ``schema.yml``.
+
+    A model is reported untested when either:
+
+    - It is not declared in any ``schema.yml`` under the project's
+      ``model-paths`` (so it has no metadata at all, tests included).
+    - It is declared in ``schema.yml`` but the entry carries neither a
+      ``tests:`` key (dbt <=1.4 spelling) nor a ``data_tests:`` key
+      (dbt >=1.5 spelling). The discovery layer normalises both into
+      :attr:`sql_guard.dbt.DbtModelEntry.has_tests`.
+
+    Fires once per .sql file inside the project's ``model-paths``.
+    Files outside those paths (macros, analyses, seeds, snapshots) are
+    skipped so the rule does not fire on infrastructure that isn't a
+    model. Silent unless ``--dbt`` is supplied because the rule is only
+    registered when :func:`sql_guard.rules.build_dbt_rules` is called
+    with a discovered :class:`DbtProject`.
+    """
+
+    id = "DBT001"
+    name = "model-without-test"
+    severity = "warning"
+    description = "dbt model has no tests: entry in schema.yml"
+
+    def __init__(self, project: DbtProject) -> None:
+        self._project = project
+
+    def check_file(self, file: str) -> list[Finding]:
+        path = Path(file)
+        if path.suffix != ".sql":
+            return []
+
+        resolved = path.resolve()
+        in_models = any(
+            _is_relative_to(resolved, model_dir)
+            for model_dir in self._project.model_paths
+        )
+        if not in_models:
+            return []
+
+        model_name = path.stem
+        entry = next(
+            (m for m in self._project.models if m.name == model_name),
+            None,
+        )
+        if entry is not None and entry.has_tests:
+            return []
+
+        return [
+            Finding(
+                rule_id=self.id,
+                severity=self.severity,
+                file=file,
+                line=1,
+                message=f"dbt model '{model_name}' has no tests: entry in schema.yml",
+                suggestion=(
+                    "Add a tests: (or data_tests:) block for this model in "
+                    "schema.yml, or add the model to schema.yml if it is "
+                    "missing entirely."
+                ),
+            )
+        ]
+
+
+def _is_relative_to(child: Path, parent: Path) -> bool:
+    """Cross-version Path.is_relative_to helper.
+
+    Python's ``Path.is_relative_to`` was added in 3.9 and is fine on the
+    supported versions, but the inline ``try / except ValueError``
+    works regardless of platform path-resolution quirks on Windows.
+    """
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True

--- a/sql_guard/rules/dbt.py
+++ b/sql_guard/rules/dbt.py
@@ -1,0 +1,14 @@
+"""dbt-aware rule pack (DBT001-DBT00N).
+
+Opt-in via the ``--dbt`` CLI flag. Each rule consumes a
+:class:`sql_guard.dbt.DbtProject` describing the discovered project
+layout and reads ``schema.yml`` / ``dbt_project.yml`` at lint time.
+Silent unless ``--dbt`` is supplied; existing users see no behaviour
+change.
+
+Severity split, per the ADR:
+- ``warning``: DBT001, DBT002, DBT005, DBT006
+- ``error``:   DBT003, DBT004, DBT007
+"""
+
+from __future__ import annotations

--- a/sql_guard/rules/dbt.py
+++ b/sql_guard/rules/dbt.py
@@ -54,8 +54,7 @@ class ModelWithoutTest(Rule):
 
         resolved = path.resolve()
         in_models = any(
-            _is_relative_to(resolved, model_dir)
-            for model_dir in self._project.model_paths
+            _is_relative_to(resolved, model_dir) for model_dir in self._project.model_paths
         )
         if not in_models:
             return []

--- a/tests/fixtures/dbt_project/dbt_project.yml
+++ b/tests/fixtures/dbt_project/dbt_project.yml
@@ -1,0 +1,7 @@
+name: test_project
+version: '1.0.0'
+config-version: 2
+
+profile: test_project
+
+model-paths: ["models"]

--- a/tests/fixtures/dbt_project/models/marts/schema.yml
+++ b/tests/fixtures/dbt_project/models/marts/schema.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: fct_orders
+    data_tests:
+      - unique:
+          column_name: order_id
+
+  - name: fct_customers

--- a/tests/fixtures/dbt_project/models/staging/schema.yml
+++ b/tests/fixtures/dbt_project/models/staging/schema.yml
@@ -1,0 +1,8 @@
+version: 2
+
+models:
+  - name: stg_orders
+    description: "Raw orders from the source system."
+    tests:
+      - unique:
+          column_name: order_id

--- a/tests/test_dbt_discovery.py
+++ b/tests/test_dbt_discovery.py
@@ -113,9 +113,7 @@ def test_load_dbt_project_falls_back_to_default_model_paths(tmp_path):
 
 def test_load_dbt_project_explicit_multiple_model_paths(tmp_path):
     project_yml = tmp_path / "dbt_project.yml"
-    project_yml.write_text(
-        'name: x\nmodel-paths: ["models", "transforms"]\n'
-    )
+    project_yml.write_text('name: x\nmodel-paths: ["models", "transforms"]\n')
     (tmp_path / "models").mkdir()
     (tmp_path / "transforms").mkdir()
     project = load_dbt_project(project_yml)

--- a/tests/test_dbt_discovery.py
+++ b/tests/test_dbt_discovery.py
@@ -1,0 +1,123 @@
+"""Tests for sql_guard.dbt project discovery and schema.yml parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sql_guard.dbt import find_dbt_project, load_dbt_project
+
+
+FIXTURE_PROJECT = Path(__file__).parent / "fixtures" / "dbt_project"
+
+
+# find_dbt_project ----------------------------------------------------------
+
+
+def test_find_dbt_project_finds_yml_in_same_dir(tmp_path):
+    (tmp_path / "dbt_project.yml").write_text("name: x\n")
+    assert find_dbt_project(tmp_path) == (tmp_path / "dbt_project.yml").resolve()
+
+
+def test_find_dbt_project_walks_up_from_subdir(tmp_path):
+    project_yml = tmp_path / "dbt_project.yml"
+    project_yml.write_text("name: x\n")
+    sub = tmp_path / "models" / "marts"
+    sub.mkdir(parents=True)
+    assert find_dbt_project(sub) == project_yml.resolve()
+
+
+def test_find_dbt_project_accepts_file_input(tmp_path):
+    project_yml = tmp_path / "dbt_project.yml"
+    project_yml.write_text("name: x\n")
+    sub = tmp_path / "models"
+    sub.mkdir()
+    sql_file = sub / "model.sql"
+    sql_file.write_text("SELECT 1;\n")
+    assert find_dbt_project(sql_file) == project_yml.resolve()
+
+
+def test_find_dbt_project_returns_none_when_absent(tmp_path):
+    # No dbt_project.yml in this tree. The function may still return a
+    # path outside tmp_path if the real filesystem ancestors host one;
+    # only assert that nothing inside tmp_path is reported.
+    sub = tmp_path / "deep" / "nested" / "dir"
+    sub.mkdir(parents=True)
+    result = find_dbt_project(sub)
+    if result is not None:
+        assert not str(result.resolve()).startswith(str(tmp_path.resolve()))
+
+
+# load_dbt_project ----------------------------------------------------------
+
+
+def test_load_dbt_project_reads_model_paths_from_fixture():
+    project = load_dbt_project(FIXTURE_PROJECT / "dbt_project.yml")
+    assert (FIXTURE_PROJECT / "models").resolve() in project.model_paths
+
+
+def test_load_dbt_project_finds_all_models_in_fixture():
+    project = load_dbt_project(FIXTURE_PROJECT / "dbt_project.yml")
+    names = {m.name for m in project.models}
+    assert names == {"stg_orders", "fct_orders", "fct_customers"}
+
+
+def test_load_dbt_project_recognises_tests_key():
+    # dbt <= 1.4 spelling.
+    project = load_dbt_project(FIXTURE_PROJECT / "dbt_project.yml")
+    stg = next(m for m in project.models if m.name == "stg_orders")
+    assert stg.has_tests is True
+
+
+def test_load_dbt_project_recognises_data_tests_key():
+    # dbt >= 1.5 spelling.
+    project = load_dbt_project(FIXTURE_PROJECT / "dbt_project.yml")
+    fct = next(m for m in project.models if m.name == "fct_orders")
+    assert fct.has_tests is True
+
+
+def test_load_dbt_project_model_without_tests():
+    project = load_dbt_project(FIXTURE_PROJECT / "dbt_project.yml")
+    fct = next(m for m in project.models if m.name == "fct_customers")
+    assert fct.has_tests is False
+
+
+def test_load_dbt_project_captures_description():
+    project = load_dbt_project(FIXTURE_PROJECT / "dbt_project.yml")
+    stg = next(m for m in project.models if m.name == "stg_orders")
+    assert stg.description == "Raw orders from the source system."
+
+
+def test_load_dbt_project_missing_description_is_none():
+    project = load_dbt_project(FIXTURE_PROJECT / "dbt_project.yml")
+    fct = next(m for m in project.models if m.name == "fct_customers")
+    assert fct.description is None
+
+
+def test_load_dbt_project_malformed_schema_yml_does_not_crash(tmp_path):
+    project_yml = tmp_path / "dbt_project.yml"
+    project_yml.write_text('name: x\nmodel-paths: ["models"]\n')
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "schema.yml").write_text("not: [valid yaml")
+    project = load_dbt_project(project_yml)
+    assert project.models == ()
+
+
+def test_load_dbt_project_falls_back_to_default_model_paths(tmp_path):
+    project_yml = tmp_path / "dbt_project.yml"
+    project_yml.write_text("name: x\n")  # no model-paths key
+    project = load_dbt_project(project_yml)
+    paths = {p.name for p in project.model_paths}
+    assert paths == {"models"}
+
+
+def test_load_dbt_project_explicit_multiple_model_paths(tmp_path):
+    project_yml = tmp_path / "dbt_project.yml"
+    project_yml.write_text(
+        'name: x\nmodel-paths: ["models", "transforms"]\n'
+    )
+    (tmp_path / "models").mkdir()
+    (tmp_path / "transforms").mkdir()
+    project = load_dbt_project(project_yml)
+    paths = {p.name for p in project.model_paths}
+    assert paths == {"models", "transforms"}

--- a/tests/test_dbt_rules.py
+++ b/tests/test_dbt_rules.py
@@ -9,9 +9,7 @@ from sql_guard.rules import build_dbt_rules, get_rules
 from sql_guard.rules.dbt import ModelWithoutTest
 
 
-FIXTURE_PROJECT_YML = (
-    Path(__file__).parent / "fixtures" / "dbt_project" / "dbt_project.yml"
-)
+FIXTURE_PROJECT_YML = Path(__file__).parent / "fixtures" / "dbt_project" / "dbt_project.yml"
 FIXTURE_MODELS = FIXTURE_PROJECT_YML.parent / "models"
 
 
@@ -54,9 +52,7 @@ def test_dbt001_message_names_the_model():
 
 def test_dbt001_fires_on_unregistered_model(tmp_path):
     # A .sql model under model-paths with no schema.yml entry at all.
-    (tmp_path / "dbt_project.yml").write_text(
-        'name: x\nmodel-paths: ["models"]\n'
-    )
+    (tmp_path / "dbt_project.yml").write_text('name: x\nmodel-paths: ["models"]\n')
     models = tmp_path / "models" / "marts"
     models.mkdir(parents=True)
     rogue = models / "fct_rogue.sql"
@@ -79,9 +75,7 @@ def test_dbt001_skips_non_sql_file():
 
 def test_dbt001_skips_file_outside_model_paths(tmp_path):
     # Tiny project where the .sql file lives in macros/, not models/.
-    (tmp_path / "dbt_project.yml").write_text(
-        'name: x\nmodel-paths: ["models"]\n'
-    )
+    (tmp_path / "dbt_project.yml").write_text('name: x\nmodel-paths: ["models"]\n')
     macros = tmp_path / "macros"
     macros.mkdir()
     macro = macros / "helper.sql"
@@ -125,9 +119,7 @@ def test_cli_dbt_flag_activates_dbt001(tmp_path):
     from sql_guard.cli import app
 
     # Tiny dbt project with one untested model.
-    (tmp_path / "dbt_project.yml").write_text(
-        'name: x\nmodel-paths: ["models"]\n'
-    )
+    (tmp_path / "dbt_project.yml").write_text('name: x\nmodel-paths: ["models"]\n')
     models = tmp_path / "models" / "marts"
     models.mkdir(parents=True)
     untested = models / "fct_orders.sql"
@@ -144,9 +136,7 @@ def test_cli_without_dbt_flag_does_not_fire_dbt001(tmp_path):
 
     from sql_guard.cli import app
 
-    (tmp_path / "dbt_project.yml").write_text(
-        'name: x\nmodel-paths: ["models"]\n'
-    )
+    (tmp_path / "dbt_project.yml").write_text('name: x\nmodel-paths: ["models"]\n')
     models = tmp_path / "models" / "marts"
     models.mkdir(parents=True)
     untested = models / "fct_orders.sql"

--- a/tests/test_dbt_rules.py
+++ b/tests/test_dbt_rules.py
@@ -113,3 +113,45 @@ def test_get_rules_includes_dbt_pack_when_project_supplied():
     rules = get_rules(dbt_project=project)
     ids = {r.id for r in rules}
     assert "DBT001" in ids
+
+
+# CLI integration -----------------------------------------------------------
+
+
+def test_cli_dbt_flag_activates_dbt001(tmp_path):
+    """End-to-end: --dbt flag discovers the project and fires DBT001."""
+    from typer.testing import CliRunner
+
+    from sql_guard.cli import app
+
+    # Tiny dbt project with one untested model.
+    (tmp_path / "dbt_project.yml").write_text(
+        'name: x\nmodel-paths: ["models"]\n'
+    )
+    models = tmp_path / "models" / "marts"
+    models.mkdir(parents=True)
+    untested = models / "fct_orders.sql"
+    untested.write_text("SELECT 1 AS id;\n")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", "--dbt", str(untested)])
+    assert "DBT001" in result.stdout
+
+
+def test_cli_without_dbt_flag_does_not_fire_dbt001(tmp_path):
+    """Same project, no --dbt: rule is silent."""
+    from typer.testing import CliRunner
+
+    from sql_guard.cli import app
+
+    (tmp_path / "dbt_project.yml").write_text(
+        'name: x\nmodel-paths: ["models"]\n'
+    )
+    models = tmp_path / "models" / "marts"
+    models.mkdir(parents=True)
+    untested = models / "fct_orders.sql"
+    untested.write_text("SELECT 1 AS id;\n")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["check", str(untested)])
+    assert "DBT001" not in result.stdout

--- a/tests/test_dbt_rules.py
+++ b/tests/test_dbt_rules.py
@@ -1,0 +1,115 @@
+"""Tests for the dbt-aware rule pack (DBT001-DBT00N)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sql_guard.dbt import load_dbt_project
+from sql_guard.rules import build_dbt_rules, get_rules
+from sql_guard.rules.dbt import ModelWithoutTest
+
+
+FIXTURE_PROJECT_YML = (
+    Path(__file__).parent / "fixtures" / "dbt_project" / "dbt_project.yml"
+)
+FIXTURE_MODELS = FIXTURE_PROJECT_YML.parent / "models"
+
+
+# DBT001 model-without-test -------------------------------------------------
+
+
+def test_dbt001_quiet_for_model_with_tests_key():
+    project = load_dbt_project(FIXTURE_PROJECT_YML)
+    rule = ModelWithoutTest(project)
+    # stg_orders uses the dbt <=1.4 `tests:` spelling.
+    path = FIXTURE_MODELS / "staging" / "stg_orders.sql"
+    assert rule.check_file(str(path)) == []
+
+
+def test_dbt001_quiet_for_model_with_data_tests_key():
+    project = load_dbt_project(FIXTURE_PROJECT_YML)
+    rule = ModelWithoutTest(project)
+    # fct_orders uses the dbt >=1.5 `data_tests:` spelling.
+    path = FIXTURE_MODELS / "marts" / "fct_orders.sql"
+    assert rule.check_file(str(path)) == []
+
+
+def test_dbt001_fires_on_model_listed_but_untested():
+    project = load_dbt_project(FIXTURE_PROJECT_YML)
+    rule = ModelWithoutTest(project)
+    path = FIXTURE_MODELS / "marts" / "fct_customers.sql"
+    findings = rule.check_file(str(path))
+    assert len(findings) == 1
+    assert findings[0].rule_id == "DBT001"
+    assert findings[0].severity == "warning"
+
+
+def test_dbt001_message_names_the_model():
+    project = load_dbt_project(FIXTURE_PROJECT_YML)
+    rule = ModelWithoutTest(project)
+    path = FIXTURE_MODELS / "marts" / "fct_customers.sql"
+    findings = rule.check_file(str(path))
+    assert "fct_customers" in findings[0].message
+
+
+def test_dbt001_fires_on_unregistered_model(tmp_path):
+    # A .sql model under model-paths with no schema.yml entry at all.
+    (tmp_path / "dbt_project.yml").write_text(
+        'name: x\nmodel-paths: ["models"]\n'
+    )
+    models = tmp_path / "models" / "marts"
+    models.mkdir(parents=True)
+    rogue = models / "fct_rogue.sql"
+    rogue.write_text("SELECT 1;\n")
+
+    project = load_dbt_project(tmp_path / "dbt_project.yml")
+    rule = ModelWithoutTest(project)
+    findings = rule.check_file(str(rogue))
+    assert len(findings) == 1
+    assert findings[0].rule_id == "DBT001"
+
+
+def test_dbt001_skips_non_sql_file():
+    project = load_dbt_project(FIXTURE_PROJECT_YML)
+    rule = ModelWithoutTest(project)
+    # A .py file even under model-paths should not be inspected -- the
+    # rule is about dbt SQL models.
+    assert rule.check_file(str(FIXTURE_MODELS / "marts" / "helper.py")) == []
+
+
+def test_dbt001_skips_file_outside_model_paths(tmp_path):
+    # Tiny project where the .sql file lives in macros/, not models/.
+    (tmp_path / "dbt_project.yml").write_text(
+        'name: x\nmodel-paths: ["models"]\n'
+    )
+    macros = tmp_path / "macros"
+    macros.mkdir()
+    macro = macros / "helper.sql"
+    macro.write_text("SELECT 1;\n")
+
+    project = load_dbt_project(tmp_path / "dbt_project.yml")
+    rule = ModelWithoutTest(project)
+    assert rule.check_file(str(macro)) == []
+
+
+# Registry wiring -----------------------------------------------------------
+
+
+def test_build_dbt_rules_returns_dbt001():
+    project = load_dbt_project(FIXTURE_PROJECT_YML)
+    rules = build_dbt_rules(project)
+    ids = {r.id for r in rules}
+    assert "DBT001" in ids
+
+
+def test_get_rules_omits_dbt_pack_by_default():
+    rules = get_rules()
+    ids = {r.id for r in rules}
+    assert "DBT001" not in ids
+
+
+def test_get_rules_includes_dbt_pack_when_project_supplied():
+    project = load_dbt_project(FIXTURE_PROJECT_YML)
+    rules = get_rules(dbt_project=project)
+    ids = {r.id for r in rules}
+    assert "DBT001" in ids


### PR DESCRIPTION
## What changed

First slice of the [dbt-aware rule pack ADR]: scaffolding + the simplest of the seven proposed rules (DBT001 `model-without-test`). The remaining six rules and the Jinja preprocessor are intentionally deferred to follow-up PRs.

**New modules:**
- `sql_guard/dbt.py` — project discovery (`find_dbt_project`, `load_dbt_project`, `DbtProject`, `DbtModelEntry`). Walks up from a path to find `dbt_project.yml`, parses `model-paths`, and reads every `schema.yml` under those paths. Supports both `tests:` (dbt ≤1.4) and `data_tests:` (dbt ≥1.5) spellings. Tolerates malformed `schema.yml` without crashing the lint run.
- `sql_guard/rules/dbt.py` — `ModelWithoutTest` rule class.

**Rule API change:**
- New `Rule.check_file(file) -> list[Finding]` extension point on the base class. Default returns `[]` so line- and statement-rules pay nothing. File-level rules (e.g. DBT001) override it. Checker runs `check_file` after the existing line and statement passes.

**Wiring:**
- `build_dbt_rules(project)` registry helper mirrors `build_contract_rules(contract)`.
- `get_rules(..., dbt_project=...)` accepts the project and appends DBT rules when set.
- `--dbt` CLI flag, auto-discovers `dbt_project.yml` from the first checked path. Silent without the flag. Surfaces a yellow warning when `--dbt` is supplied but no project is found.

## Related issue

[ADR] dbt-aware rule pack — implementation of DBT001 only; remaining rules are explicitly out of scope for this PR.

## If this adds or changes a rule

- [x] Rule ID is the next unused in its family (`DBT001`)
- [x] Rule class registered (via `build_dbt_rules` rather than `ALL_RULES`, opt-in pattern)
- [x] Fixture in `tests/fixtures/dbt_project/` (YAML only; no `.sql` files so existing `files_checked` counts aren't bumped)
- [x] "Fires on bad SQL" tests in `tests/test_dbt_rules.py`
- [x] "Does NOT fire on safe SQL" tests in `tests/test_dbt_rules.py`
- [ ] README rule table + Key Numbers count updated — deliberately skipped, see below
- [x] Rule is not a removal or rename of an existing rule

**Why no README update:** the README rule table doesn't grow until at least three DBT rules exist, to avoid churning the table on every PR while the pack is still small.

## Tests

- [x] `pytest -q` passes (280 passed, 1 skipped — up from 254 on main)
- [x] `ruff check .` passes
- New tests: 14 in `tests/test_dbt_discovery.py`, 12 in `tests/test_dbt_rules.py` (including end-to-end CLI integration).

## Checklist

- [x] One logical change per commit (9 commits, Conventional Commits style)
- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Anything else reviewers should know

**Deferred to follow-up PRs (per the ADR):**
- Jinja preprocessor (~1 week of work on its own)
- DBT002 (`direct-table-ref`), DBT003 (`incremental-without-unique-key`), DBT004 (`hook-with-ddl`), DBT005 (`select-star-in-mart`), DBT006 (`model-without-description`), DBT007 (`var-injection-risk`)

**Compatibility:**
- Default behaviour for current users is unchanged — `--dbt` is opt-in.
- The new `Rule.check_file` method has a sensible default; no existing rule needs modification.
- No new mandatory dependency (PyYAML is already required).