### PR TITLE
fix(ci): use underscore input names for first-interaction@v3

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue on sql-sop! A few pointers:
 
             - If this is a **security / rule-bypass** report, please close
@@ -41,7 +41,7 @@ jobs:
 
             The maintainer replies within 7 calendar days
             (see [`GOVERNANCE.md`](../blob/main/GOVERNANCE.md)).
-          pr-message: |
+          pr_message: |
             Thanks for your first PR on sql-sop! Quick checks:
 
             - `pytest -q` and `ruff check .` pass locally


### PR DESCRIPTION
The `welcome` workflow was failing on every PR/issue from external contributors with:

```
Error: Input required and not supplied: issue_message
```

`actions/first-interaction@v3` uses underscore input names (`repo_token`, `issue_message`, `pr_message`), but the workflow was passing the old hyphenated names (`repo-token`, `issue-message`, `pr-message`). The hyphenated keys are ignored, so the required `issue_message` was missing and the action errored before posting anything.

Renamed the three inputs to the underscore form. No message content changed.

(Owner-authored PRs skip this job via the existing `if:` guard, so this PR won't exercise it — it'll apply to the next external contributor.)